### PR TITLE
Standardized attention mask field in DPO, RM and finegrained preferences

### DIFF
--- a/compose_rl/data/preference_data.py
+++ b/compose_rl/data/preference_data.py
@@ -133,7 +133,7 @@ def pairwise_preference_dataset_collate_fn(
         'rejected_len': rejected_lens,
         'prompt_len': prompt_lens,
         'input_ids': input_ids,
-        'text_attention_mask': attention_masks,
+        'attention_mask': attention_masks,
         'sequence_id': sequence_id,
     }
     if len(chosen_rewards) > 0:
@@ -188,7 +188,7 @@ def finegrained_preference_dataset_collate_fn(
             continue
 
         batch[key] = ref_collate_fn(cur_values)['input_ids']
-    batch['text_attention_mask'] = torch.logical_not(
+    batch['attention_mask'] = torch.logical_not(
         torch.eq(batch['text'], tokenizer.pad_token_id),  # type: ignore
     )
 

--- a/compose_rl/dpo/model_methods.py
+++ b/compose_rl/dpo/model_methods.py
@@ -70,7 +70,7 @@ def dpo_forward(
     if use_attention_sequence_id:
         output_logits = model(
             batch['input_ids'],
-            attention_mask=batch['text_attention_mask'],
+            attention_mask=batch['attention_mask'],
             sequence_id=batch['sequence_id'],
         ).logits
 
@@ -95,7 +95,7 @@ def dpo_forward(
         )
 
         chosen_attention_mask, rejected_attention_mask = extract_packed_chosen_rejected(
-            batch['text_attention_mask'],
+            batch['attention_mask'],
             batch['chosen_len'],
             batch['rejected_len'],
             concat_seq_len // 2,

--- a/compose_rl/reward_learning/model_methods.py
+++ b/compose_rl/reward_learning/model_methods.py
@@ -74,7 +74,7 @@ def pairwise_forward(
     if use_attention_sequence_id:
         model_output = model(
             batch['input_ids'],
-            attention_mask=batch['text_attention_mask'],
+            attention_mask=batch['attention_mask'],
             sequence_id=batch['sequence_id'],
             return_lm_logits=return_lm_logits,
         )
@@ -100,7 +100,7 @@ def pairwise_forward(
         )
 
         chosen_attention_mask, rejected_attention_mask = extract_packed_chosen_rejected(
-            input_tensor=batch['text_attention_mask'],
+            input_tensor=batch['attention_mask'],
             chosen_len=batch['chosen_len'],
             rejected_len=batch['rejected_len'],
             max_seq_len=concat_seq_len // 2,
@@ -184,7 +184,7 @@ def classifier_forward(
 
     model_output = model(
         batch['text'],
-        attention_mask=batch['text_attention_mask'],
+        attention_mask=batch['attention_mask'],
         return_lm_logits=return_lm_logits,
     )
 

--- a/tests/test_reward_learning.py
+++ b/tests/test_reward_learning.py
@@ -139,7 +139,7 @@ def gen_random_batch(
         high=30000,
         size=(batch_size, test_cfg.max_seq_len * 2),
     ).to(device)
-    batch['text_attention_mask'] = torch.ones(
+    batch['attention_mask'] = torch.ones(
         size=(batch_size, test_cfg.max_seq_len * 2),
         dtype=torch.int64,
     ).to(device)


### PR DESCRIPTION
Changed all occurrences of `text_attention_mask` to `attention_mask` following the similar standard of llm-foundry