### PR TITLE
Updating sequence length usage

### DIFF
--- a/compose_rl/dpo/model_methods.py
+++ b/compose_rl/dpo/model_methods.py
@@ -78,7 +78,7 @@ def dpo_forward(
             output_logits,
             batch['chosen_len'],
             batch['rejected_len'],
-            concat_seq_len // 2,
+            concat_seq_len,
             pad_token_id=pad_token_id,  # type: ignore
         )
 
@@ -90,7 +90,7 @@ def dpo_forward(
             batch['input_ids'],
             batch['chosen_len'],
             batch['rejected_len'],
-            concat_seq_len // 2,
+            concat_seq_len,
             pad_token_id=pad_token_id,  # type: ignore
         )
 
@@ -98,7 +98,7 @@ def dpo_forward(
             batch['attention_mask'],
             batch['chosen_len'],
             batch['rejected_len'],
-            concat_seq_len // 2,
+            concat_seq_len,
             pad_token_id=0,
         )
 
@@ -124,7 +124,7 @@ def dpo_forward(
         batch['input_ids'],
         batch['chosen_len'],
         batch['rejected_len'],
-        concat_seq_len // 2,
+        concat_seq_len,
         pad_token_id=0,
     )
 

--- a/compose_rl/reward_learning/model_methods.py
+++ b/compose_rl/reward_learning/model_methods.py
@@ -83,7 +83,7 @@ def pairwise_forward(
             input_tensor=model_output.scores,
             chosen_len=batch['chosen_len'],
             rejected_len=batch['rejected_len'],
-            max_seq_len=concat_seq_len // 2,
+            max_seq_len=concat_seq_len,
             pad_token_id=pad_token_id,  # type: ignore
         )
 
@@ -95,7 +95,7 @@ def pairwise_forward(
             input_tensor=batch['input_ids'],
             chosen_len=batch['chosen_len'],
             rejected_len=batch['rejected_len'],
-            max_seq_len=concat_seq_len // 2,
+            max_seq_len=concat_seq_len,
             pad_token_id=pad_token_id,  # type: ignore
         )
 
@@ -103,7 +103,7 @@ def pairwise_forward(
             input_tensor=batch['attention_mask'],
             chosen_len=batch['chosen_len'],
             rejected_len=batch['rejected_len'],
-            max_seq_len=concat_seq_len // 2,
+            max_seq_len=concat_seq_len,
             pad_token_id=0,
         )
 


### PR DESCRIPTION
With this PR (https://github.com/databricks/compose-rl/commit/305014246660d2e4752153b5fdf4b902bc2ee94a) we changed how we defined `max_seq_len,` but never updated it in model usage. This PR updates it.

updated run here: 8b-bt-ui05-uf-lr3e-6-allen-uf-ui-pad-tok-new-QrRaeM
