### PR TITLE
Upper bound vllm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,21 +23,21 @@ cpu = [
 gpu = [
     'llm-foundry[all]@git+https://github.com/mosaicml/llm-foundry.git@main#egg=llmfoundry',
     'kubernetes==29.0.0',
-    'vllm>=0.8.2',
+    'vllm>=0.8.2,<0.9.0',
 ]
 dev = [
     'llm-foundry[dev]@git+https://github.com/mosaicml/llm-foundry.git@main#egg=llmfoundry',
     'kubernetes==29.0.0',
-    'vllm>=0.8.2',
+    'vllm>=0.8.2,<0.9.0',
 ]
 released = [
     'llm-foundry[all]>=0.17.1',
     'kubernetes==29.0.0',
-    'vllm>=0.8.2',
+    'vllm>=0.8.2,<0.9.0',
 ]
 cpu_released = [
     'llm-foundry[all-cpu]>=0.17.1',
-    'kubernetes==29.0.0',
+    'vllm>=0.8.2,<0.9.0',
 ]
 
 # Registry entry points


### PR DESCRIPTION
Lets not pull in the latest vllm versions without making a conscious choice. I assume they regularly make breaking changes, and dependency changes.