### PR TITLE
Update setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # build requirements
 [build-system]
-requires = ["setuptools < 68.0.0"]
+requires = ["setuptools < 79.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
wheel released a new version, that no longer has bdist_wheel in it (https://github.com/pypa/wheel/releases/tag/0.46.0), relying on the fact that is now in setuptools, but compose-rl [pins](https://github.com/databricks/compose-rl/blob/96141f75e3607fd6f6313078ca9d776ae7e474df/pyproject.toml#L3) an old setuptools, and so install fails.

This PR updates setuptools to use the latest version, 78.1.0. 

