### PR TITLE
Adding warning for truncating preferences

### DIFF
--- a/compose_rl/data/preference_data.py
+++ b/compose_rl/data/preference_data.py
@@ -79,6 +79,12 @@ def pairwise_preference_dataset_collate_fn(
             # We should truncate chosen and rejected by the same amount
             truncate_len = abs(pad_len // 2) + 1
 
+            log.warning((
+                f'Chosen length: {len(chosen)} Rejected length: {len(rejected)}'
+                f' are too long for max_seq_len: {max_seq_len}'
+                f' truncating each sequence by {truncate_len[0]} tokens.'
+            ))
+
             # Truncate each value by truncate length, and make the last token EOS
             chosen = chosen[:-truncate_len]
             chosen[-1] = tokenizer.eos_token_id  # type: ignore


### PR DESCRIPTION
As title

Example when this is triggered:
![image](https://github.com/user-attachments/assets/d6804c9a-3920-4098-a6d8-3d17c40b9f10)
