### PR TITLE
K generation per prompt

### DIFF
--- a/compose_rl/data/prompt_data.py
+++ b/compose_rl/data/prompt_data.py
@@ -101,7 +101,11 @@ class PromptStreamingDataset(StreamingDataset):
 
         prompt_len = torch.Tensor([len(prompt)]).to(dtype=torch.int64)
         # Send the prompt id along with prompt data
-        item_dict = {'prompt_id': idx, 'prompt': prompt, 'prompt_len': prompt_len}
+        item_dict = {
+            'prompt_id': idx,
+            'prompt': prompt,
+            'prompt_len': prompt_len
+        }
 
         verified_answer = sample.get('verified_answer', None)
         if verified_answer:

--- a/compose_rl/data/prompt_data.py
+++ b/compose_rl/data/prompt_data.py
@@ -44,7 +44,9 @@ def prompt_dataset_collate_fn(
         if key in ['prompt_len']:
             collated_batch[key] = torch.stack(cur_values).squeeze(dim=1)
             continue
-
+        if key == 'prompt_id':
+            collated_batch[key] = torch.tensor(cur_values)
+            continue
         if key in ['verified_answer']:
             collated_batch[key] = list(  # pyright: ignore[reportGeneralTypeIssues]
                 utils.flatten(cur_values),
@@ -57,7 +59,10 @@ def prompt_dataset_collate_fn(
         torch.eq(collated_batch['prompt'],
                  tokenizer.pad_token_id),  # type: ignore
     )
-
+    # print(f'Collated batch keys: {collated_batch.keys()}')
+    # dict_keys(['prompt_id', 'prompt', 'prompt_len', 'prompt_attention_mask'])
+    # print(f'{collated_batch=}')
+    # breakpoint()
     return collated_batch
 
 
@@ -98,7 +103,8 @@ class PromptStreamingDataset(StreamingDataset):
             prompt = prompt[:-truncate_len]
 
         prompt_len = torch.Tensor([len(prompt)]).to(dtype=torch.int64)
-        item_dict = {'prompt': prompt, 'prompt_len': prompt_len}
+        # Send the prompt id along with prompt data
+        item_dict = {'prompt_id': idx, 'prompt': prompt, 'prompt_len': prompt_len}
 
         verified_answer = sample.get('verified_answer', None)
         if verified_answer:

--- a/compose_rl/data/prompt_data.py
+++ b/compose_rl/data/prompt_data.py
@@ -104,7 +104,7 @@ class PromptStreamingDataset(StreamingDataset):
         item_dict = {
             'prompt_id': idx,
             'prompt': prompt,
-            'prompt_len': prompt_len
+            'prompt_len': prompt_len,
         }
 
         verified_answer = sample.get('verified_answer', None)

--- a/compose_rl/data/prompt_data.py
+++ b/compose_rl/data/prompt_data.py
@@ -59,10 +59,7 @@ def prompt_dataset_collate_fn(
         torch.eq(collated_batch['prompt'],
                  tokenizer.pad_token_id),  # type: ignore
     )
-    # print(f'Collated batch keys: {collated_batch.keys()}')
-    # dict_keys(['prompt_id', 'prompt', 'prompt_len', 'prompt_attention_mask'])
-    # print(f'{collated_batch=}')
-    # breakpoint()
+
     return collated_batch
 
 

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -444,7 +444,7 @@ class PPOCallback(CallbackWithConfig):
         self.precision = state.precision
         self.device_train_microbatch_size: int = state.device_train_microbatch_size  # type: ignore
 
-        # Scale the iteration batch size by generations_per_prompt 
+        # Scale the iteration batch size by generations_per_prompt
         self.iter_batch_size = self.num_batches_per_update * self.device_train_batch_size * self.generations_per_prompt
 
         # The KL penalty in the reward should only exist if we aren't minimizing
@@ -637,7 +637,7 @@ class PPOCallback(CallbackWithConfig):
                 idx=i,
                 minibatch_size=self.device_generate_batch_size,
             )
-            for k in range(self.generations_per_prompt):
+            for _ in range(self.generations_per_prompt):
                 env_outputs, prompts_and_gens, ref_outputs, all_rewards_dict = env_generate(
                     actor_critic=self.actor_critic,  # pyright: ignore
                     vllm_engines=self.vllm_engines,
@@ -659,7 +659,7 @@ class PPOCallback(CallbackWithConfig):
                 # Add gen_batch self.generations_per_prompt times to the exploded batch
                 gen_batch_clone = gen_batch.copy()
                 exploded_batch.append(gen_batch_clone)
-        # Concatenate all mini batches together    
+        # Concatenate all mini batches together
         exploded_batch = self._merge_minibatches(exploded_batch)
 
         # For every partial output we want to resolve them together
@@ -713,7 +713,7 @@ class PPOCallback(CallbackWithConfig):
             for batch_key, tensor in batch.items()
         }
         return curr_gen_batch
-    
+
     def _merge_minibatches(self, minibatches: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
         """Merges a list of minibatches into a single batch.
 
@@ -772,7 +772,7 @@ class PPOCallback(CallbackWithConfig):
 
         for key in outputs[0].keys():
             env_outputs[key] = torch.cat([output[key] for output in outputs])
-        
+
         # Now that rewards are resolved, we can compute advantages
         env_outputs['advantages'] = compute_advantages(
             rewards=env_outputs['rewards'],

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -364,7 +364,9 @@ class PPOCallback(CallbackWithConfig):
         if self.num_batches_per_update % self.generations_per_prompt != 0:
             error_msg = f'{self.num_batches_per_update=} must be divisible by {self.generations_per_prompt=}'
             raise ValueError(error_msg)
-        effective_gen_minibatches = (self.num_batches_per_update // self.generations_per_prompt)  * self.device_train_batch_size
+        effective_gen_minibatches = (
+            self.num_batches_per_update // self.generations_per_prompt
+        ) * self.device_train_batch_size
         if effective_gen_minibatches % self.device_generate_batch_size != 0:
             error_msg = f'For {self.num_batches_per_update=}, {self.generations_per_prompt=} and {self.device_train_batch_size=}, {effective_gen_minibatches=} must be divisible by {self.device_generate_batch_size=}'
             raise ValueError(error_msg)

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -364,6 +364,10 @@ class PPOCallback(CallbackWithConfig):
         if self.num_batches_per_update % self.generations_per_prompt != 0:
             error_msg = f'{self.num_batches_per_update=} must be divisible by {self.generations_per_prompt=}'
             raise ValueError(error_msg)
+        effective_gen_minibatches = (self.num_batches_per_update // self.generations_per_prompt)  * self.device_train_batch_size
+        if effective_gen_minibatches % self.device_generate_batch_size != 0:
+            error_msg = f'For {self.num_batches_per_update=}, {self.generations_per_prompt=} and {self.device_train_batch_size=}, {effective_gen_minibatches=} must be divisible by {self.device_generate_batch_size=}'
+            raise ValueError(error_msg)
         self.epochs_per_iteration = ensure_time(
             var_config.get('epoch_per_iteration', 1),
             TimeUnit.EPOCH,

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -368,7 +368,9 @@ class PPOCallback(CallbackWithConfig):
         assert self.epochs_per_iteration.unit == TimeUnit.EPOCH
 
         # Programmatically setting the max buffer size instead of the yaml
-        var_config['buffer']['max_buffer_size'] = self.num_batches_per_update * self.generations_per_prompt
+        var_config['buffer'
+                  ]['max_buffer_size'
+                   ] = self.num_batches_per_update * self.generations_per_prompt
         self.buffer = MinibatchRolloutBuffer(var_config['buffer'])
         self.kl_ctl = build_kl_controller(var_config['kl_controller'])
 
@@ -627,7 +629,6 @@ class PPOCallback(CallbackWithConfig):
         # We can have the generate size be greater than the device train microbatch size
         num_gen_calls = self.num_batches_per_update * self.device_train_batch_size // self.device_generate_batch_size
 
-
         gen_batch_partial_outputs = []
         exploded_batch = []
         for i in range(num_gen_calls):
@@ -645,7 +646,8 @@ class PPOCallback(CallbackWithConfig):
                     batch=gen_batch,
                     max_gen_len=self.max_gen_len,
                     precision=self.precision,
-                    device_train_microbatch_size=self.device_train_microbatch_size,
+                    device_train_microbatch_size=self.
+                    device_train_microbatch_size,
                     generation_kwargs=self.generation_kwargs,
                     tokenizer=self.tokenizer,  # type: ignore
                     eos_token_ids=self.eos_token_ids,  # type: ignore
@@ -680,7 +682,9 @@ class PPOCallback(CallbackWithConfig):
             self.buffer.add(minibatch)
 
         # Making sure we correctly parsed the minibatches
-        assert len(self.buffer) == self.num_batches_per_update * self.generations_per_prompt
+        assert len(
+            self.buffer
+        ) == self.num_batches_per_update * self.generations_per_prompt
 
         self.actor_critic.train()
 
@@ -714,7 +718,9 @@ class PPOCallback(CallbackWithConfig):
         }
         return curr_gen_batch
 
-    def _merge_minibatches(self, minibatches: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
+    def _merge_minibatches(
+        self, minibatches: list[dict[str, torch.Tensor]]
+    ) -> dict[str, torch.Tensor]:
         """Merges a list of minibatches into a single batch.
 
         Args:
@@ -774,7 +780,6 @@ class PPOCallback(CallbackWithConfig):
             output['right_padded_attn_mask'] = torch.logical_not(
                 torch.eq(output['obs'], self.pad_token_idx),  # type: ignore
             )
-
 
         for key in outputs[0].keys():
             env_outputs[key] = torch.cat([output[key] for output in outputs])

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -633,10 +633,10 @@ class PPOCallback(CallbackWithConfig):
         """
         # Determine the number of generating calls we want to make
         # We can have the generate size be greater than the device train microbatch size
-        num_gen_minibatches = self.num_batches_per_update * self.device_train_batch_size // self.device_generate_batch_size
+        num_gen_calls = self.num_batches_per_update * self.device_train_batch_size // self.device_generate_batch_size
 
         gen_batch_partial_outputs = []
-        for i in range(num_gen_minibatches):
+        for i in range(num_gen_calls):
             # Extract a minibatch of size device_generate_batch_size from the full batch
             gen_batch = self._extract_minibatch(
                 batch=batch,

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -643,6 +643,7 @@ class PPOCallback(CallbackWithConfig):
                 idx=i,
                 minibatch_size=self.device_generate_batch_size,
             )
+
             env_outputs, prompts_and_gens, ref_outputs, all_rewards_dict = env_generate(
                 actor_critic=self.actor_critic,  # pyright: ignore
                 vllm_engines=self.vllm_engines,
@@ -712,29 +713,6 @@ class PPOCallback(CallbackWithConfig):
             for batch_key, tensor in batch.items()
         }
         return curr_gen_batch
-
-    def _merge_minibatches(
-        self,
-        minibatches: list[dict[str, torch.Tensor]],
-    ) -> dict[str, torch.Tensor]:
-        """Merges a list of minibatches into a single batch.
-
-        Args:
-            minibatches (list[dict[str, torch.Tensor]]): A list of minibatches to merge.
-
-        Returns:
-            merged_batch (dict[str, torch.Tensor]): The merged batch.
-        """
-        merged_batch = {}
-        for key in minibatches[0].keys():
-            # Handle verified_answer separately
-            if key in ['verified_answer']:
-                merged_batch[key] = list(  # pyright: ignore[reportGeneralTypeIssues]
-                    utils.flatten([mb[key] for mb in minibatches]),
-                )
-            else:
-                merged_batch[key] = torch.cat([mb[key] for mb in minibatches])
-        return merged_batch
 
     def _resolve_outputs(
         self,

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -363,8 +363,9 @@ class PPOCallback(CallbackWithConfig):
         )
 
         if self.num_batches_per_update % self.generations_per_prompt != 0:
-            error_msg = f'{self.num_batches_per_update=} must be divisible by {self.generations_per_prompt=}'
-            raise ValueError(error_msg)
+            raise ValueError(
+                f'{self.num_batches_per_update=} must be divisible by {self.generations_per_prompt=}',
+            )
 
         self.epochs_per_iteration = ensure_time(
             var_config.get('epoch_per_iteration', 1),

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -637,7 +637,6 @@ class PPOCallback(CallbackWithConfig):
 
         gen_batch_partial_outputs = []
         for i in range(num_gen_calls):
-            # Extract a minibatch of size device_generate_batch_size from the full batch
             gen_batch = self._extract_minibatch(
                 batch=batch,
                 idx=i,

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -628,7 +628,9 @@ class PPOCallback(CallbackWithConfig):
         # Determine the number of generating calls we want to make
         # We can have the generate size be greater than the device train microbatch size
         # Total num_gen_minibatches will be scaled down by generations_per_prompt
-        num_gen_minibatches = (self.num_batches_per_update // self.generations_per_prompt)  * self.device_train_batch_size // self.device_generate_batch_size
+        num_gen_minibatches = (
+            self.num_batches_per_update // self.generations_per_prompt
+        ) * self.device_train_batch_size // self.device_generate_batch_size
 
         gen_batch_partial_outputs = []
         exploded_batch = []

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -555,12 +555,10 @@ class PPOCallback(CallbackWithConfig):
 
     def _get_next_iter_prompts(self):
         """Gets the next iteration's batch of prompts."""
-
         # Sample fewer batches for the Online RL interation depending on the number of generations per prompt
         n_unique_batches = self.num_batches_per_update // self.generations_per_prompt
         batches = [
-            self._get_single_batch_prompts()
-            for _ in range(n_unique_batches)
+            self._get_single_batch_prompts() for _ in range(n_unique_batches)
         ]
 
         ret_batch = {}
@@ -587,7 +585,8 @@ class PPOCallback(CallbackWithConfig):
                         if (batch[key][:, -1] == padding_key).any():
                             raise ValueError(
                                 'The last token in the prompt should not be the pad token. Please double '
-                                + 'check the dataloader and prompt and dataloader.',
+                                +
+                                'check the dataloader and prompt and dataloader.',
                             )
                     elif key == 'prompt_attention_mask':
                         padding_key = False
@@ -651,8 +650,7 @@ class PPOCallback(CallbackWithConfig):
                 batch=gen_batch,
                 max_gen_len=self.max_gen_len,
                 precision=self.precision,
-                device_train_microbatch_size=self.
-                device_train_microbatch_size,
+                device_train_microbatch_size=self.device_train_microbatch_size,
                 generation_kwargs=self.generation_kwargs,
                 tokenizer=self.tokenizer,  # type: ignore
                 eos_token_ids=self.eos_token_ids,  # type: ignore

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -683,7 +683,7 @@ class PPOCallback(CallbackWithConfig):
 
         # Making sure we correctly parsed the minibatches
         assert len(
-            self.buffer
+            self.buffer,
         ) == self.num_batches_per_update * self.generations_per_prompt
 
         self.actor_critic.train()
@@ -719,7 +719,8 @@ class PPOCallback(CallbackWithConfig):
         return curr_gen_batch
 
     def _merge_minibatches(
-        self, minibatches: list[dict[str, torch.Tensor]]
+        self,
+        minibatches: list[dict[str, torch.Tensor]],
     ) -> dict[str, torch.Tensor]:
         """Merges a list of minibatches into a single batch.
 

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -725,7 +725,13 @@ class PPOCallback(CallbackWithConfig):
         """
         merged_batch = {}
         for key in minibatches[0].keys():
-            merged_batch[key] = torch.cat([mb[key] for mb in minibatches])
+            # Handle verified_answer separately
+            if key in ['verified_answer']:
+                merged_batch[key] = list(  # pyright: ignore[reportGeneralTypeIssues]
+                    utils.flatten([mb[key] for mb in minibatches]),
+                )
+            else:
+                merged_batch[key] = torch.cat([mb[key] for mb in minibatches])
         return merged_batch
 
     def _resolve_outputs(

--- a/yamls/local_ppo.yaml
+++ b/yamls/local_ppo.yaml
@@ -48,6 +48,7 @@ variables:
 
   epoch_per_iteration: 1
   num_batches_per_update: 8
+  generations_per_prompt: 4
 
   max_gen_len: 32
 


### PR DESCRIPTION
Adds the ability to do K-generations per prompt in each environment interaction (`iter` in composer). Key changes include:
- New variable `generations_per_prompt` in the ppo yaml. Defaults to `1`. 
    - Modifies the `_get_next_iter_prompts` inner loop to `generations_per_prompt` times per minibatch.
- Variable `buffer.max_buffer_size` now autoset as `num_batches_per_update`
- Added `prompt_id` in dataloader.

Working run `mcli logs retry-4-gen-8b-math-6k-gen-8k-seq-nokl-Xahsv9 -f`