### PR TITLE
Fast inference w/ single vllm generate call per PPO iter

### DIFF
--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -11,7 +11,7 @@ import os
 import socket
 import time
 from itertools import chain
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import ray
 import torch
@@ -129,8 +129,8 @@ def env_reward(
 
         start_gen_time = time.time()
 
-        assert 'sequences' in batch, f"sequences is not in batch {batch.keys()=}"
-        
+        assert 'sequences' in batch, f'sequences is not in batch {batch.keys()=}'
+
         sequences = batch['sequences']
 
         num_tokens_generated = sequences.size(1) - prompt_tokens.size(1)
@@ -206,9 +206,7 @@ def env_reward(
             generated_text = tokenizer.decode(  # type:  ignore
                 get_decoded_sequence(actions[i], generated_len[i],
                                             max_gen_len))
-            untokenized_prompt_and_responses.append(
-                (prompt, generated_text),
-            )
+            untokenized_prompt_and_responses.append((prompt, generated_text),)
 
         # Making logits [batch_size, generated_len, vocab_size]
         # We need to recompute the logits here. Otherwise there are numerical differences
@@ -229,9 +227,10 @@ def env_reward(
         # Compute the device_train_microbatch_log_probs inside the for loop to reduce the softmax overhead
         for i in range(batch_size // device_train_microbatch_size):
             curr_kwargs = {
-                key: value[i * device_train_microbatch_size:(i + 1) *
-                            device_train_microbatch_size]
-                if isinstance(value, torch.Tensor) else value
+                key:
+                    value[i * device_train_microbatch_size:(i + 1) *
+                          device_train_microbatch_size]
+                    if isinstance(value, torch.Tensor) else value
                 for key, value in input_model_kwargs.items()
             }
             cur_output = actor_critic(curr_kwargs)
@@ -258,7 +257,7 @@ def env_reward(
             action_mask,
             torch.zeros((batch_size, 1), device=cur_device),
         ],
-                                        dim=-1)
+                                      dim=-1)
         device_train_microbatch_values *= value_action_mask
 
         partial_env_output = {
@@ -694,10 +693,9 @@ class PPOCallback(CallbackWithConfig):
             max_gen_len=self.max_gen_len,
             precision=self.precision,
             device_train_microbatch_size=self.device_train_microbatch_size,
-            kl_estimator=self.kl_estimator,
-            generation_kwargs=self.generation_kwargs,
             tokenizer=self.tokenizer,  # type: ignore
             eos_token_ids=self.eos_token_ids,  # type: ignore
+            kl_estimator=self.kl_estimator,
         )
 
         self.prompts_and_gens.extend(prompts_and_gens)

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -31,7 +31,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 import compose_rl.utils as utils
 from compose_rl.ppo.buffer import MinibatchRolloutBuffer
-from compose_rl.ppo.generation_utils import generate
+from compose_rl.ppo.generation_utils import hf_generate
 from compose_rl.ppo.model import ComposerHFPolicyModel, ComposerMosaicPolicy
 from compose_rl.ppo.reward_manager import (
     ReferenceOutput,
@@ -56,12 +56,187 @@ from compose_rl.utils import (
 Tokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
 Policy = Union[ComposerHFPolicyModel, ComposerMosaicPolicy]
 
-__all__ = ['PPOCallback', 'env_generate']
+__all__ = ['PPOCallback', 'env_reward']
 
 log = logging.getLogger(__name__)
 
+def vllm_generate(
+    # actor_critic: Policy,
+    vllm_engines: Optional[list],
+    # reward_manager: RewardManager,
+    batch: dict,
+    max_gen_len: int,
+    # precision: Precision,
+    # device_train_microbatch_size: int,
+    generation_kwargs: dict,
+    tokenizer: Tokenizer,
+    # eos_token_ids: list[int],
+) -> torch.Tensor:
+    """Run vllm generate on the prompts.
 
-def env_generate(
+    Runs generate over a set of sequences in the batch. It also does extra computation
+    that is required for later loss computation.
+
+    Args:
+        actor_critic (ComposerMosaicPolicy): Actor critic model to run generate over.
+        reward_manager (RewardManager): Composes the reference IFT model and all generate models.
+        batch (dict): The batch of data to run generate over.
+        max_gen_len (int): Maximum generation length.
+        precision (Precision): Precision to run computation.
+        device_train_microbatch_size (int): Device train microbatch size for the training job.
+            We need to do all log_prob computation with this in order to maintain numerics.
+        generation_kwargs (dict): Generation keyword arguments.
+        tokenizer (Tokenizer): The actor critic's tokenizer.
+        eos_token_ids (list[int]): A list of eos token ids.
+
+    Returns:
+        sequences (tensor): Tensor containing the prompt and generated sequences.
+            The shape of the tensor is [batch_size, prompt_len + max_gen_len].
+
+    Note:
+        Use the .get() method on an AsyncResult object (see Returns, above) to resolve it.
+    """
+    # 1. Gather all prompts from all ranks
+    # 2. Run generate over all prompts in one go
+    # 3. Scatter the generated responses back to the correct rank
+    # 4. Save the tokenized sequences in the batch for future use
+    pad_token_id = tokenizer.pad_token_id  # type: ignore
+    cur_device = batch['prompt'].device
+    prompt_tokens = batch['prompt']
+    # Pull the necessary variables from the batch and self
+    prompt_all_gather_start_time = time.time()
+
+    all_batched_prompts = dist.all_gather_object(prompt_tokens)
+    batch_sizes = [len(batch) for batch in all_batched_prompts]
+
+    log.info(
+        f'took : {time.time() - prompt_all_gather_start_time} to gather prompts',
+    )
+    all_prompts = [
+        prompt for batch in all_batched_prompts for prompt in batch
+    ]
+
+    if dist.get_global_rank() == 0:
+        futs = []
+        sampling_params = {
+            'temperature': generation_kwargs.get('temperature', 1.0),
+            'top_p': generation_kwargs.get('top_p', 1.0),
+            'top_k': generation_kwargs.get('top_k', 50),
+            'max_tokens': max_gen_len,
+        }
+
+        # We have to remove all pad tokens here
+        all_prompts = [[
+            token
+            for token in prompt.detach().cpu().tolist()
+            if token != pad_token_id
+        ]
+                    for prompt in all_prompts]
+
+        # Generate with vllm
+        # Calculate the base batch size
+        vllm_batch_size = len(all_prompts) // len(vllm_engines)
+        # Calculate the remainder (prompts that don't fit evenly)
+        remainder = len(all_prompts) % len(vllm_engines)
+
+        start_idx = 0
+        for i, engine in enumerate(vllm_engines):
+            # Assign one extra prompt to the first 'remainder' engines
+            if i < remainder:
+                end_idx = start_idx + vllm_batch_size + 1
+            else:
+                end_idx = start_idx + vllm_batch_size
+
+            cur_prompts_ids = all_prompts[start_idx:end_idx]
+            cur_prompts = [
+                tokenizer.decode(prompt)  # type: ignore
+                for prompt in cur_prompts_ids
+            ]
+
+            futs.append(
+                engine.generate.remote(
+                    cur_prompts,
+                    sampling_params=sampling_params,
+                ),
+            )
+
+            # Update the start index for the next iteration
+            start_idx = end_idx
+
+        start_time = time.time()
+        results = ray.get(futs)
+        all_responses = []
+
+        # Get all of the ray futures
+        for i, result in enumerate(results):
+            # Each result is a list of responses this assumes one output per input
+            all_responses.extend([
+                resp.outputs[0].token_ids for resp in result
+            ])
+
+        log.info(
+            f'took: {time.time() - start_time} to gather futures',
+        )
+
+        # Distribute padded responses back to the correct device
+        split_responses = []
+        start = 0
+        for size in batch_sizes:
+            split_responses.append(
+                all_responses[start:start + size],
+            )
+            start += size
+    else:
+        # Remove the memory from all gather as they are only used for the first rank
+        all_batched_prompts = None
+        all_prompts = None
+        split_responses = None
+
+    # Do another garbage collection and empty the cache
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    dist.barrier()
+
+    # Scatter the generated responses back to the correct rank
+    local_responses = [None]
+    start_time = time.time()
+    torch.distributed.scatter_object_list(
+        local_responses,
+        split_responses,
+        src=0,
+    )
+    local_responses = local_responses[0]
+
+    log.info(f'took: {time.time() - start_time} to scatter prompts')
+
+    # Pad the responses to the maximum length
+    max_vllm_generated_len = max([
+        len(response) for response in local_responses  # type: ignore
+    ])
+    padded_responses = []
+    for sequence in local_responses:  # type: ignore
+        sequence = list(sequence)
+        if len(sequence) < max_vllm_generated_len:
+            sequence = sequence + [
+                pad_token_id,
+            ] * (max_vllm_generated_len - len(sequence))
+
+        padded_responses.append(sequence)
+
+    # Convert the padded responses to a tensor
+    padded_responses = torch.tensor(
+        padded_responses,
+        dtype=prompt_tokens.dtype,
+        device=cur_device,
+    )
+
+    # Construct full sequences from the prompt and padded responses
+    sequences = torch.cat([prompt_tokens, padded_responses], dim=-1)
+    return sequences
+
+def env_reward(
     actor_critic: Policy,
     vllm_engines: Optional[list],
     reward_manager: RewardManager,
@@ -79,15 +254,15 @@ def env_generate(
     ReferenceOutput,
     RewardOutput,
 ]:
-    """Run generate from the model.
+    """Run reward on the model generated responses.
 
-    Runs generate over a set of prompts in the batch. It also does extra computation
+    Runs reward over a set of sequences in the batch. It also does extra computation
     that is required for later loss computation.
 
     Args:
-        actor_critic (ComposerMosaicPolicy): Actor critic model to run generate over.
+        actor_critic (ComposerMosaicPolicy): Actor critic model to run reward over.
         reward_manager (RewardManager): Composes the reference IFT model and all reward models.
-        batch (dict): The batch of data to run generate over.
+        batch (dict): The batch of data to run reward over.
         max_gen_len (int): Maximum generation length.
         precision (Precision): Precision to run computation.
         device_train_microbatch_size (int): Device train microbatch size for the training job.
@@ -110,8 +285,7 @@ def env_generate(
             then all_rewards["X"] will be an AsyncResult object that will resolve to associated reward tensor.
 
     Note:
-        Use the .get() method on an AsyncResult object (see Returns, above) to resolve it. This method
-        is blocking.
+        Use the .get() method on an AsyncResult object (see Returns, above) to resolve it.
     """
     prompt_tokens = batch['prompt']
 
@@ -124,193 +298,175 @@ def env_generate(
             'Tokenizer does not have a pad token id. Please use a different tokenizer or add a pad token id.',
         )
 
-    with get_precision_context(precision):
+    with get_precision_context(precision), torch.no_grad():
         prompt_len = batch['prompt_len']
         verified_answers = batch.get('verified_answer', None)
         prompt_id = batch['prompt_id']
+        cur_device = prompt_tokens.device
+        prompt_dtype = prompt_tokens.dtype
 
-        with torch.no_grad():
-            cur_device = prompt_tokens.device
-            prompt_dtype = prompt_tokens.dtype
+        start_gen_time = time.time()
 
-            start_gen_time = time.time()
+        assert 'sequences' in batch, f"sequences is not in batch {batch.keys()=}"
+        
+        sequences = batch['sequences']
 
-            if 'sequences' in batch:
-                # If we have sequences in the batch, we can use them directly
-                sequences = batch['sequences']
-            else:
-                # Otherwise, we need to run generate
-                sequences = generate(
-                    actor_critic,
-                    vllm_engines,
-                    max_gen_len,
-                    batch,
-                    pad_token_id, # type: ignore
-                    tokenizer,
-                    generation_kwargs,
-                )
-                print(f"Shapes inside env generate: {prompt_tokens.shape=}")
-                print(f"{prompt_tokens=}")
-                print(f"Shapes inside env generate: {sequences.shape=}")
-                
+        num_tokens_generated = sequences.size(1) - prompt_tokens.size(1)
 
-            num_tokens_generated = sequences.size(1) - prompt_tokens.size(1)
+        log.info(
+            f'It took {time.time() - start_gen_time} to generate {num_tokens_generated} tokens',
+        )
 
-            log.info(
-                f'It took {time.time() - start_gen_time} to generate {num_tokens_generated} tokens',
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        generated_len = torch.ones(
+            batch_size,
+            device=cur_device,
+            dtype=prompt_dtype,
+        ) * max_gen_len
+
+        # If all the processes early exit generate, then we need to manually pad everything
+        # we can pad this with pad tokens, since we switch the padding between left and right
+        # padding based on the sequence length + max_sequence_length.
+        if prompt_tokens.size(1) + max_gen_len > sequences.size(1):
+            len_to_pad = max_gen_len - (
+                sequences.size(1) - prompt_tokens.size(1)
             )
 
-            gc.collect()
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
-
-            generated_len = torch.ones(
-                batch_size,
+            extra_padding = torch.ones(
+                (batch_size, len_to_pad),
                 device=cur_device,
                 dtype=prompt_dtype,
-            ) * max_gen_len
-
-            # If all the processes early exit generate, then we need to manually pad everything
-            # we can pad this with pad tokens, since we switch the padding between left and right
-            # padding based on the sequence length + max_sequence_length.
-            if prompt_tokens.size(1) + max_gen_len > sequences.size(1):
-                len_to_pad = max_gen_len - (
-                    sequences.size(1) - prompt_tokens.size(1)
-                )
-
-                extra_padding = torch.ones(
-                    (batch_size, len_to_pad),
-                    device=cur_device,
-                    dtype=prompt_dtype,
-                ) * pad_token_id
-                sequences = torch.cat(
-                    [sequences, extra_padding],  # type: ignore
-                    dim=-1,  # type: ignore
-                )
-
-            # Sanity checking we're adding max_gen_len to prompt_tokens
-            assert prompt_tokens.size(1) + max_gen_len == sequences.size(1)
-
-            # Actions are what tokens the current policy would generate.
-            actions = sequences[:, -max_gen_len:]
-
-            right_padded_obs = switch_left_to_right_padding(
-                sequences,
-                prompt_len,
-                max_gen_len,
-                pad_token_id,  # type: ignore
-            )
-            right_padded_attn_mask = torch.logical_not(
-                torch.eq(right_padded_obs, pad_token_id),  # type: ignore
+            ) * pad_token_id
+            sequences = torch.cat(
+                [sequences, extra_padding],  # type: ignore
+                dim=-1,  # type: ignore
             )
 
-            (
-                right_padded_obs,
-                right_padded_attn_mask,
-                generated_len,
-                action_mask,
-            ) = mask_eos(
-                actions=actions,
-                right_padded_obs=right_padded_obs,
-                right_padded_attn_mask=right_padded_attn_mask,
-                prompt_len=prompt_len,
-                generated_len=generated_len,
+        # Sanity checking we're adding max_gen_len to prompt_tokens
+        assert prompt_tokens.size(1) + max_gen_len == sequences.size(1)
+
+        # Actions are what tokens the current policy would generate.
+        actions = sequences[:, -max_gen_len:]
+
+        right_padded_obs = switch_left_to_right_padding(
+            sequences,
+            prompt_len,
+            max_gen_len,
+            pad_token_id,  # type: ignore
+        )
+        right_padded_attn_mask = torch.logical_not(
+            torch.eq(right_padded_obs, pad_token_id),  # type: ignore
+        )
+
+        (
+            right_padded_obs,
+            right_padded_attn_mask,
+            generated_len,
+            action_mask,
+        ) = mask_eos(
+            actions=actions,
+            right_padded_obs=right_padded_obs,
+            right_padded_attn_mask=right_padded_attn_mask,
+            prompt_len=prompt_len,
+            generated_len=generated_len,
+            max_gen_len=max_gen_len,
+            eos_token_ids=eos_token_ids,  # type: ignore
+            pad_token=pad_token_id,  # type: ignore
+        )
+
+        untokenized_prompt_and_responses = []
+        for i in range(batch_size):
+            prompt = tokenizer.decode(  # type: ignore
+                right_padded_obs[i, :prompt_len[i]])
+            generated_text = tokenizer.decode(  # type:  ignore
+                get_decoded_sequence(actions[i], generated_len[i],
+                                            max_gen_len))
+            untokenized_prompt_and_responses.append(
+                (prompt, generated_text),
+            )
+
+        # Making logits [batch_size, generated_len, vocab_size]
+        # We need to recompute the logits here. Otherwise there are numerical differences
+        # We also need to do it on the size of `device_train_microbatch_size` otherwise
+        # there are numerical differences at training time.
+        # log probs will be [batch_size, generated_len]
+        log_probs = []
+        values = []
+
+        input_model_kwargs = {
+            'obs': right_padded_obs,
+            'right_padded_attn_mask': right_padded_attn_mask,
+            'prompt_len': prompt_len,
+            'max_gen_len': max_gen_len,
+            'action_mask': action_mask,
+            'actions': actions,
+        }
+        # Compute the device_train_microbatch_log_probs inside the for loop to reduce the softmax overhead
+        for i in range(batch_size // device_train_microbatch_size):
+            curr_kwargs = {
+                key: value[i * device_train_microbatch_size:(i + 1) *
+                            device_train_microbatch_size]
+                if isinstance(value, torch.Tensor) else value
+                for key, value in input_model_kwargs.items()
+            }
+            cur_output = actor_critic(curr_kwargs)
+            cur_logits = cur_output['logits']
+            cur_values = cur_output['values']
+            # need to pull out current actions and prompt len
+            cur_actions = curr_kwargs['actions']
+            cur_prompt_len = curr_kwargs['prompt_len']
+
+            cur_log_probs = get_log_probs(
+                logits=cur_logits,
+                actions=cur_actions,
+                prompt_len=cur_prompt_len,
                 max_gen_len=max_gen_len,
-                eos_token_ids=eos_token_ids,  # type: ignore
-                pad_token=pad_token_id,  # type: ignore
             )
+            log_probs.append(cur_log_probs)
+            values.append(cur_values)
 
-            untokenized_prompt_and_responses = []
-            for i in range(batch_size):
-                prompt = tokenizer.decode(  # type: ignore
-                    right_padded_obs[i, :prompt_len[i]])
-                generated_text = tokenizer.decode(  # type:  ignore
-                    get_decoded_sequence(actions[i], generated_len[i],
-                                               max_gen_len))
-                untokenized_prompt_and_responses.append(
-                    (prompt, generated_text),
-                )
+        device_train_microbatch_log_probs = torch.cat(log_probs)
+        device_train_microbatch_values = torch.cat(values)
 
-            # Making logits [batch_size, generated_len, vocab_size]
-            # We need to recompute the logits here. Otherwise there are numerical differences
-            # We also need to do it on the size of `device_train_microbatch_size` otherwise
-            # there are numerical differences at training time.
-            # log probs will be [batch_size, generated_len]
-            log_probs = []
-            values = []
+        # Need to add in the padding for the value function
+        value_action_mask = torch.cat([
+            action_mask,
+            torch.zeros((batch_size, 1), device=cur_device),
+        ],
+                                        dim=-1)
+        device_train_microbatch_values *= value_action_mask
 
-            input_model_kwargs = {
-                'obs': right_padded_obs,
-                'right_padded_attn_mask': right_padded_attn_mask,
-                'prompt_len': prompt_len,
-                'max_gen_len': max_gen_len,
-                'action_mask': action_mask,
-                'actions': actions,
-            }
-            # Compute the device_train_microbatch_log_probs inside the for loop to reduce the softmax overhead
-            for i in range(batch_size // device_train_microbatch_size):
-                curr_kwargs = {
-                    key:
-                        value[i * device_train_microbatch_size:(i + 1) *
-                              device_train_microbatch_size]
-                        if isinstance(value, torch.Tensor) else value
-                    for key, value in input_model_kwargs.items()
-                }
-                cur_output = actor_critic(curr_kwargs)
-                cur_logits = cur_output['logits']
-                cur_values = cur_output['values']
-                # need to pull out current actions and prompt len
-                cur_actions = curr_kwargs['actions']
-                cur_prompt_len = curr_kwargs['prompt_len']
+        partial_env_output = {
+            'prompt_id': prompt_id,
+            'actions': actions.detach(),
+            'old_log_probs': device_train_microbatch_log_probs.detach(),
+            'obs': right_padded_obs.detach(),
+            'generated_len': generated_len,
+            'action_mask': action_mask,
+            'values': device_train_microbatch_values.detach(),
+        }
 
-                cur_log_probs = get_log_probs(
-                    logits=cur_logits,
-                    actions=cur_actions,
-                    prompt_len=cur_prompt_len,
-                    max_gen_len=max_gen_len,
-                )
-                log_probs.append(cur_log_probs)
-                values.append(cur_values)
+        # Future implementations may change the way reward_seq_len is defined
+        # e.g., if special formatting is applied
+        reward_seq_len = prompt_len + generated_len
 
-            device_train_microbatch_log_probs = torch.cat(log_probs)
-            device_train_microbatch_values = torch.cat(values)
-
-            # Need to add in the padding for the value function
-            value_action_mask = torch.cat([
-                action_mask,
-                torch.zeros((batch_size, 1), device=cur_device),
-            ],
-                                          dim=-1)
-            device_train_microbatch_values *= value_action_mask
-
-            partial_env_output = {
-                'prompt_id': prompt_id,
-                'actions': actions.detach(),
-                'old_log_probs': device_train_microbatch_log_probs.detach(),
-                'obs': right_padded_obs.detach(),
-                'generated_len': generated_len,
-                'action_mask': action_mask,
-                'values': device_train_microbatch_values.detach(),
-            }
-
-            # Future implementations may change the way reward_seq_len is defined
-            # e.g., if special formatting is applied
-            reward_seq_len = prompt_len + generated_len
-
-            ref_output, all_rewards = reward_manager(
-                raw_untokenized_texts=untokenized_prompt_and_responses,
-                right_padded_obses=right_padded_obs,
-                attention_masks=right_padded_attn_mask,
-                seq_lens=reward_seq_len,
-                generated_lens=generated_len,
-                prompt_lens=prompt_len,
-                max_gen_length=max_gen_len,
-                actions=actions,
-                action_log_probs=device_train_microbatch_log_probs,
-                device_train_microbatch_size=device_train_microbatch_size,
-                kl_estimator=kl_estimator,
-                verified_answers=verified_answers,
-            )
+        ref_output, all_rewards = reward_manager(
+            raw_untokenized_texts=untokenized_prompt_and_responses,
+            right_padded_obses=right_padded_obs,
+            attention_masks=right_padded_attn_mask,
+            seq_lens=reward_seq_len,
+            generated_lens=generated_len,
+            prompt_lens=prompt_len,
+            max_gen_length=max_gen_len,
+            actions=actions,
+            action_log_probs=device_train_microbatch_log_probs,
+            device_train_microbatch_size=device_train_microbatch_size,
+            kl_estimator=kl_estimator,
+            verified_answers=verified_answers,
+        )
 
     return (
         partial_env_output,
@@ -657,206 +813,78 @@ class PPOCallback(CallbackWithConfig):
         Args:
             batch (dict): the iteration level batch we want to interact with the environment.
         """
-        # If vllm engines are available
-        # 1. Gather all prompts from all ranks
-        # 2. Run generate over all prompts in one go
-        # 3. Scatter the generated responses back to the correct rank
-        # 4. Save the tokenized sequences in the batch for future use
-        vllm_engines = self.vllm_engines
         max_gen_len = self.max_gen_len
-        tokenizer = self.tokenizer
-        pad_token_id = tokenizer.pad_token_id  # type: ignore
+        pad_token_id = self.pad_token_idx
         generation_kwargs = self.generation_kwargs
-        precision = self.precision
-        cur_device = batch['prompt'].device
-        prompt_tokens = batch['prompt']
-        with get_precision_context(precision), torch.no_grad():
-            if vllm_engines is not None:
-                # Pull the necessary variables from the batch and self
-                prompt_all_gather_start_time = time.time()
-
-                all_batched_prompts = dist.all_gather_object(prompt_tokens)
-                batch_sizes = [len(batch) for batch in all_batched_prompts]
-
-                log.info(
-                    f'took : {time.time() - prompt_all_gather_start_time} to gather prompts',
+        with get_precision_context(self.precision), torch.no_grad():
+            # If vllm engines are available, we use them to generate sequences in one go
+            if self.vllm_engines is not None:
+                sequences = vllm_generate(
+                    # actor_critic=self.actor_critic,
+                    vllm_engines=self.vllm_engines,
+                    # reward_manager=self.reward_manager,
+                    batch=batch,
+                    max_gen_len=max_gen_len,
+                    # precision=self.precision,
+                    # device_train_microbatch_size=self.device_train_microbatch_size,
+                    generation_kwargs=generation_kwargs,
+                    tokenizer=self.tokenizer,  # type: ignore
+                    # eos_token_ids=self.eos_token_ids,  # type: ignore
                 )
-                all_prompts = [
-                    prompt for batch in all_batched_prompts for prompt in batch
-                ]
-
-                if dist.get_global_rank() == 0:
-                    futs = []
-                    sampling_params = {
-                        'temperature': generation_kwargs.get('temperature', 1.0),
-                        'top_p': generation_kwargs.get('top_p', 1.0),
-                        'top_k': generation_kwargs.get('top_k', 50),
-                        'max_tokens': max_gen_len,
-                    }
-
-                    # We have to remove all pad tokens here
-                    all_prompts = [[
-                        token
-                        for token in prompt.detach().cpu().tolist()
-                        if token != pad_token_id
-                    ]
-                                for prompt in all_prompts]
-
-                    # Generate with vllm
-                    # Calculate the base batch size
-                    vllm_batch_size = len(all_prompts) // len(vllm_engines)
-                    # Calculate the remainder (prompts that don't fit evenly)
-                    remainder = len(all_prompts) % len(vllm_engines)
-
-                    start_idx = 0
-                    for i, engine in enumerate(vllm_engines):
-                        # Assign one extra prompt to the first 'remainder' engines
-                        if i < remainder:
-                            end_idx = start_idx + vllm_batch_size + 1
-                        else:
-                            end_idx = start_idx + vllm_batch_size
-
-                        cur_prompts_ids = all_prompts[start_idx:end_idx]
-                        cur_prompts = [
-                            tokenizer.decode(prompt)  # type: ignore
-                            for prompt in cur_prompts_ids
-                        ]
-
-                        futs.append(
-                            engine.generate.remote(
-                                cur_prompts,
-                                sampling_params=sampling_params,
-                            ),
-                        )
-
-                        # Update the start index for the next iteration
-                        start_idx = end_idx
-
-                    start_time = time.time()
-                    results = ray.get(futs)
-                    all_responses = []
-
-                    # Get all of the ray futures
-                    for i, result in enumerate(results):
-                        # Each result is a list of responses this assumes one output per input
-                        all_responses.extend([
-                            resp.outputs[0].token_ids for resp in result
-                        ])
-
-                    log.info(
-                        f'took: {time.time() - start_time} to gather futures',
-                    )
-
-                    # Distribute padded responses back to the correct device
-                    split_responses = []
-                    start = 0
-                    for size in batch_sizes:
-                        split_responses.append(
-                            all_responses[start:start + size],
-                        )
-                        start += size
-                else:
-                    # Remove the memory from all gather as they are only used for the first rank
-                    all_batched_prompts = None
-                    all_prompts = None
-                    split_responses = None
-
-                # Do another garbage collection and empty the cache
-                gc.collect()
-                if torch.cuda.is_available():
-                    torch.cuda.empty_cache()
-
-                dist.barrier()
-
-                # Scatter the generated responses back to the correct rank
-                local_responses = [None]
-                start_time = time.time()
-                torch.distributed.scatter_object_list(
-                    local_responses,
-                    split_responses,
-                    src=0,
-                )
-                local_responses = local_responses[0]
-
-                log.info(f'took: {time.time() - start_time} to scatter prompts')
-
-                # Pad the responses to the maximum length
-                max_vllm_generated_len = max([
-                    len(response) for response in local_responses  # type: ignore
-                ])
-                padded_responses = []
-                for sequence in local_responses:  # type: ignore
-                    sequence = list(sequence)
-                    if len(sequence) < max_vllm_generated_len:
-                        sequence = sequence + [
-                            pad_token_id,
-                        ] * (max_vllm_generated_len - len(sequence))
-
-                    padded_responses.append(sequence)
-
-                # Convert the padded responses to a tensor
-                padded_responses = torch.tensor(
-                    padded_responses,
-                    dtype=prompt_tokens.dtype,
-                    device=cur_device,
-                )
-
-                # Construct full sequences from the prompt and padded responses
-                sequences = torch.cat([prompt_tokens, padded_responses], dim=-1)
-                
-                # Add the prepared sequences to the batch again
-                batch['sequences'] = sequences
-
             else:
                 # Go the HF policy generate route
-                sequences = generate(
-                    self.actor_critic,
-                    vllm_engines,
-                    max_gen_len,
-                    batch,
-                    pad_token_id, # type: ignore
-                    tokenizer,
-                    generation_kwargs,
-                )
-                print(f"Shapes outside env generate: {prompt_tokens.shape=}")
-                print(f"{prompt_tokens=}")
-                print(f"Shapes outside env generate: {sequences.shape=}")
-                # breakpoint()
+                # Need to explicitly minibatch here to avoid memory issues
+                # Determine the number of generating calls we want to make
+                # We can have the generate size be greater than the device train microbatch size
+                num_gen_calls = self.num_batches_per_update * self.device_train_batch_size // self.device_generate_batch_size
+
+                gen_batch_partial_outputs = []
+                all_sequences = []
+                for i in range(num_gen_calls):
+                    gen_batch = self._extract_minibatch(
+                        batch=batch,
+                        idx=i,
+                        minibatch_size=self.device_generate_batch_size,
+                    )
+                    gen_sequences = hf_generate(
+                        self.actor_critic,
+                        max_gen_len,
+                        gen_batch,
+                        pad_token_id, # type: ignore
+                        generation_kwargs,
+                    )
+                    all_sequences.append(gen_sequences)
+                # Add right padding to all sequences and concatenate them
+                max_len = max([seq.shape[1] for seq in all_sequences])
+                padded_sequences = []
+                for sequence in all_sequences:
+                    padded_sequence = add_right_padding(
+                        sequence,
+                        max_len,
+                        self.pad_token_idx,  # type: ignore
+                    )
+                    padded_sequences.append(padded_sequence)
+                sequences = torch.cat(padded_sequences, dim=0)
         # Add the prepared sequences to the batch again
-        # batch['sequences'] = sequences
+        batch['sequences'] = sequences
 
-        # Determine the number of generating calls we want to make
-        # We can have the generate size be greater than the device train microbatch size
-        num_gen_calls = self.num_batches_per_update * self.device_train_batch_size // self.device_generate_batch_size
+        env_outputs, prompts_and_gens, ref_outputs, all_rewards_dict = env_reward(
+            actor_critic=self.actor_critic,  # pyright: ignore
+            vllm_engines=self.vllm_engines,
+            reward_manager=self.reward_manager,
+            batch=batch,
+            max_gen_len=self.max_gen_len,
+            precision=self.precision,
+            device_train_microbatch_size=self.device_train_microbatch_size,
+            kl_estimator=self.kl_estimator,
+            generation_kwargs=self.generation_kwargs,
+            tokenizer=self.tokenizer,  # type: ignore
+            eos_token_ids=self.eos_token_ids,  # type: ignore
+        )
 
-        gen_batch_partial_outputs = []
-        for i in range(num_gen_calls):
-            gen_batch = self._extract_minibatch(
-                batch=batch,
-                idx=i,
-                minibatch_size=self.device_generate_batch_size,
-            )
+        self.prompts_and_gens.extend(prompts_and_gens)
 
-            env_outputs, prompts_and_gens, ref_outputs, all_rewards_dict = env_generate(
-                actor_critic=self.actor_critic,  # pyright: ignore
-                vllm_engines=self.vllm_engines,
-                reward_manager=self.reward_manager,
-                batch=gen_batch,
-                max_gen_len=self.max_gen_len,
-                precision=self.precision,
-                device_train_microbatch_size=self.device_train_microbatch_size,
-                generation_kwargs=self.generation_kwargs,
-                tokenizer=self.tokenizer,  # type: ignore
-                eos_token_ids=self.eos_token_ids,  # type: ignore
-                kl_estimator=self.kl_estimator,
-            )
-
-            self.prompts_and_gens.extend(prompts_and_gens)
-
-            gen_batch_partial_outputs.append(
-                (env_outputs, ref_outputs, all_rewards_dict),
-            )
-        breakpoint()
+        gen_batch_partial_outputs = (env_outputs, ref_outputs, all_rewards_dict)
         # For every partial output we want to resolve them together
         # And compute the global per iteration batch advantage's mean and variance
         resolved_outputs = self._resolve_outputs(
@@ -911,30 +939,30 @@ class PPOCallback(CallbackWithConfig):
     def _resolve_outputs(
         self,
         iter_batch: dict[str, torch.Tensor],
-        partial_outputs: list[tuple[dict, ReferenceOutput, RewardOutput]],
+        partial_outputs: tuple[dict, ReferenceOutput, RewardOutput],
     ) -> dict[str, torch.Tensor]:
         """Resolve env/reference/reward outputs into a PPO minibatch.
 
         Args:
             iter_batch (dict): The batch for the current iteration.
-            partial_outputs (list): A list of (env_output, reference_output, reward_output) tuples,
-                one tuple for each generate batch size. This tuple is created from `env_generate`.
+            partial_outputs (tuple): A tuple of (env_output, reference_output, reward_output),
+                one tuple for entire ppo iter batch. This tuple is created from `env_reward`.
 
         Returns:
             output_minibatch (dict): The final minibatch from the environment, with all AsyncResult
                 objects resolved and outputs processed for PPO training.
         """
         outputs = []
-        for env_outs, ref_outs, rew_dict in partial_outputs:
-            rew_outs = self.reward_manager.resolve_outputs(
-                ref_output=ref_outs,
-                reward_output=rew_dict,
-                kl_ctl=self.kl_ctl,
-                action_mask=env_outs['action_mask'],
-                center_reward_mean=self.center_reward_mean,
-            )
-            env_outs.update(rew_outs)
-            outputs.append(env_outs)
+        env_outs, ref_outs, rew_dict = partial_outputs
+        rew_outs = self.reward_manager.resolve_outputs(
+            ref_output=ref_outs,
+            reward_output=rew_dict,
+            kl_ctl=self.kl_ctl,
+            action_mask=env_outs['action_mask'],
+            center_reward_mean=self.center_reward_mean,
+        )
+        env_outs.update(rew_outs)
+        outputs.append(env_outs)
 
         env_outputs = {}
         # Repadding all observations, right padded attention masks to the same length for composer.

--- a/compose_rl/ppo/generation_utils.py
+++ b/compose_rl/ppo/generation_utils.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import Optional, Union
 
+import gc
 import ray
 import torch
 from composer.utils import dist
@@ -31,7 +32,7 @@ def hf_generate(
     pad_token_id: int,
     generation_kwargs: dict,
 ) -> torch.Tensor:
-    """Runs generate over the batch of prompts. Only for HF generate
+    """Runs hf generate over the batch of prompts.
 
     Args:
         actor_critic (torch.nn.Module): The actor critic model to run generate over.
@@ -78,4 +79,168 @@ def hf_generate(
     # Sequences are [batch, seq_len + generated_len], covering the initial prompt and generated values
     sequences = generated_dict['sequences']  # type: ignore
 
+    return sequences
+
+def vllm_generate(
+    vllm_engines: Optional[list],
+    batch: dict,
+    max_gen_len: int,
+    generation_kwargs: dict,
+    tokenizer: Tokenizer,
+) -> torch.Tensor:
+    """Run vllm generate on the prompts.
+
+    Runs generate over a set of sequences in the batch. It also does extra computation
+    that is required for later loss computation.
+
+    Args:
+        vllm_engines (list): List of vllm engines to run generate over.
+        batch (dict): The batch of data to run generate over.
+        max_gen_len (int): Maximum generation length.
+        generation_kwargs (dict): Generation keyword arguments.
+        tokenizer (Tokenizer): The actor critic's tokenizer.
+
+    Returns:
+        sequences (tensor): Tensor containing the prompt and generated sequences.
+            The shape of the tensor is [batch_size, prompt_len + max_gen_len].
+    """
+    # 1. Gather all prompts from all ranks
+    # 2. Run generate over all prompts in one go
+    # 3. Scatter the generated responses back to the correct rank
+    # 4. Save the tokenized sequences in the batch for future use
+    pad_token_id = tokenizer.pad_token_id  # type: ignore
+    # Pull the necessary variables from the batch and self
+    cur_device = batch['prompt'].device
+    prompt_tokens = batch['prompt']
+
+    prompt_all_gather_start_time = time.time()
+
+    all_batched_prompts = dist.all_gather_object(prompt_tokens)
+    batch_sizes = [len(batch) for batch in all_batched_prompts]
+
+    log.info(
+        f'took : {time.time() - prompt_all_gather_start_time} to gather prompts',
+    )
+    all_prompts = [
+        prompt for batch in all_batched_prompts for prompt in batch
+    ]
+
+    if dist.get_global_rank() == 0:
+        futs = []
+        sampling_params = {
+            'temperature': generation_kwargs.get('temperature', 1.0),
+            'top_p': generation_kwargs.get('top_p', 1.0),
+            'top_k': generation_kwargs.get('top_k', 50),
+            'max_tokens': max_gen_len,
+        }
+
+        # We have to remove all pad tokens here
+        all_prompts = [[
+            token
+            for token in prompt.detach().cpu().tolist()
+            if token != pad_token_id
+        ]
+                    for prompt in all_prompts]
+
+        # Generate with vllm
+        # Calculate the base batch size
+        vllm_batch_size = len(all_prompts) // len(vllm_engines)
+        # Calculate the remainder (prompts that don't fit evenly)
+        remainder = len(all_prompts) % len(vllm_engines)
+
+        start_idx = 0
+        for i, engine in enumerate(vllm_engines):
+            # Assign one extra prompt to the first 'remainder' engines
+            if i < remainder:
+                end_idx = start_idx + vllm_batch_size + 1
+            else:
+                end_idx = start_idx + vllm_batch_size
+
+            cur_prompts_ids = all_prompts[start_idx:end_idx]
+            cur_prompts = [
+                tokenizer.decode(prompt)  # type: ignore
+                for prompt in cur_prompts_ids
+            ]
+
+            futs.append(
+                engine.generate.remote(
+                    cur_prompts,
+                    sampling_params=sampling_params,
+                ),
+            )
+
+            # Update the start index for the next iteration
+            start_idx = end_idx
+
+        start_time = time.time()
+        results = ray.get(futs)
+        all_responses = []
+
+        # Get all of the ray futures
+        for i, result in enumerate(results):
+            # Each result is a list of responses this assumes one output per input
+            all_responses.extend([
+                resp.outputs[0].token_ids for resp in result
+            ])
+
+        log.info(
+            f'took: {time.time() - start_time} to gather futures',
+        )
+
+        # Distribute padded responses back to the correct device
+        split_responses = []
+        start = 0
+        for size in batch_sizes:
+            split_responses.append(
+                all_responses[start:start + size],
+            )
+            start += size
+    else:
+        # Remove the memory from all gather as they are only used for the first rank
+        all_batched_prompts = None
+        all_prompts = None
+        split_responses = None
+
+    # Do another garbage collection and empty the cache
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    dist.barrier()
+
+    # Scatter the generated responses back to the correct rank
+    local_responses = [None]
+    start_time = time.time()
+    torch.distributed.scatter_object_list(
+        local_responses,
+        split_responses,
+        src=0,
+    )
+    local_responses = local_responses[0]
+
+    log.info(f'took: {time.time() - start_time} to scatter prompts')
+
+    # Pad the responses to the maximum length
+    max_vllm_generated_len = max([
+        len(response) for response in local_responses  # type: ignore
+    ])
+    padded_responses = []
+    for sequence in local_responses:  # type: ignore
+        sequence = list(sequence)
+        if len(sequence) < max_vllm_generated_len:
+            sequence = sequence + [
+                pad_token_id,
+            ] * (max_vllm_generated_len - len(sequence))
+
+        padded_responses.append(sequence)
+
+    # Convert the padded responses to a tensor
+    padded_responses = torch.tensor(
+        padded_responses,
+        dtype=prompt_tokens.dtype,
+        device=cur_device,
+    )
+
+    # Construct full sequences from the prompt and padded responses
+    sequences = torch.cat([prompt_tokens, padded_responses], dim=-1)
     return sequences

--- a/compose_rl/ppo/generation_utils.py
+++ b/compose_rl/ppo/generation_utils.py
@@ -24,173 +24,58 @@ Policy = Union[ComposerHFPolicyModel, ComposerMosaicPolicy]
 log = logging.getLogger(__name__)
 
 
-def generate(
+def hf_generate(
     actor_critic: torch.nn.Module,
-    vllm_engines: Optional[list],
     max_gen_len: int,
     batch: dict[str, torch.Tensor],
     pad_token_id: int,
-    tokenizer: Tokenizer,
     generation_kwargs: dict,
 ) -> torch.Tensor:
-    """Runs generate over the batch of prompts.
+    """Runs generate over the batch of prompts. Only for HF generate
 
     Args:
         actor_critic (torch.nn.Module): The actor critic model to run generate over.
-        vllm_engines (list): List of VLLM engines to use for generation.
         max_gen_len (int): Maximum generation length.
         batch (dict): The batch of data to run generate over.
         pad_token_id (int): The pad token id.
-        tokenizer (Tokenizer): The tokenizer to use for decoding.
         generation_kwargs (dict): Generation keyword arguments.
     """
     cur_device = batch['prompt'].device
     prompt_tokens = batch['prompt']
-    batch_size = batch['prompt'].shape[0]
 
-    if vllm_engines is not None:
-        prompt_all_gather_start_time = time.time()
-        all_batched_prompts = dist.all_gather_object(prompt_tokens)
-        log.info(
-            f'took : {time.time() - prompt_all_gather_start_time} to gather prompts',
-        )
-        all_prompts = [
-            prompt for batch in all_batched_prompts for prompt in batch
-        ]
+    policy = actor_critic.model
+    policy.eval()  # type: ignore
+    # Adding a dummy forwards call.
+    # We need this otherwise FSDP throws an error during a standard forward pass.
+    policy( # type: ignore
+        torch.tensor([[0]], dtype=torch.long, device=cur_device),
+        attention_mask=torch.tensor([[1]],
+                                    dtype=torch.bool,
+                                    device=cur_device),
+    )
 
-        batch_sizes = [len(batch) for batch in all_batched_prompts]
+    # Generate doesn't work if we unpad the FFN. So we need to check if we
+    # need to flip the flag in the model.
+    flipped_usage = flip_pad_token_usage_for_generate(
+        policy,  # type: ignore
+    )
 
-        if dist.get_global_rank() == 0:
-            futs = []
-            sampling_params = {
-                'temperature': generation_kwargs.get('temperature', 1.0),
-                'top_p': generation_kwargs.get('top_p', 1.0),
-                'top_k': generation_kwargs.get('top_k', 50),
-                'max_tokens': max_gen_len,
-            }
+    # We don't need to include EOS tokens since we mask out EOS tokens below
+    generated_dict = policy.generate( # type: ignore
+        prompt_tokens,
+        max_new_tokens=max_gen_len,
+        return_dict_in_generate=True,
+        synced_gpus=True,
+        attention_mask=batch['prompt_attention_mask'],
+        pad_token_id=pad_token_id,
+        **generation_kwargs,
+    )
 
-            # We have to remove all pad tokens here
-            all_prompts = [[
-                token
-                for token in prompt.detach().cpu().tolist()
-                if token != pad_token_id
-            ]
-                           for prompt in all_prompts]
+    # We should flip the flag back after generate as needed.
+    if flipped_usage:
+        flip_pad_token_usage_in_ffn(policy)  # type: ignore
 
-            # Calculate the base batch size
-            batch_size = len(all_prompts) // len(vllm_engines)
-            # Calculate the remainder (prompts that don't fit evenly)
-            remainder = len(all_prompts) % len(vllm_engines)
-
-            start_idx = 0
-            for i, engine in enumerate(vllm_engines):
-                # Assign one extra prompt to the first 'remainder' engines
-                if i < remainder:
-                    end_idx = start_idx + batch_size + 1
-                else:
-                    end_idx = start_idx + batch_size
-
-                cur_prompts = all_prompts[start_idx:end_idx]
-                cur_prompts = [
-                    tokenizer.decode(prompt) for prompt in cur_prompts
-                ]
-                futs.append(
-                    engine.generate.remote(
-                        cur_prompts,
-                        sampling_params=sampling_params,
-                    ),
-                )
-
-                # Update the start index for the next iteration
-                start_idx = end_idx
-
-            start_time = time.time()
-            results = ray.get(futs)
-            all_responses = []
-
-            # Get all of the ray futures
-            for i, result in enumerate(results):
-                # Each result is a list of responses this assumes one output per input
-                all_responses.extend([
-                    resp.outputs[0].token_ids for resp in result
-                ])
-
-            log.info(f'took: {time.time() - start_time} to gather futures')
-            split_responses = []
-            start = 0
-            for size in batch_sizes:
-                split_responses.append(all_responses[start:start + size])
-                start += size
-        else:
-            split_responses = None
-
-        dist.barrier()
-        # scatter the respective responses to all other ranks
-        local_responses = [None]
-        start_time = time.time()
-        torch.distributed.scatter_object_list(
-            local_responses,
-            split_responses,
-            src=0,
-        )
-        log.info(f'took: {time.time() - start_time} to scatter prompts')
-
-        local_responses = local_responses[0]
-
-        max_vllm_generated_len = max([
-            len(response) for response in local_responses  # type: ignore
-        ])
-        padded_responses = []
-        for sequence in local_responses:  # type: ignore
-            sequence = list(sequence)
-            if len(sequence) < max_vllm_generated_len:
-                sequence = sequence + [
-                    pad_token_id,
-                ] * (max_vllm_generated_len - len(sequence))
-
-            padded_responses.append(sequence)
-        padded_responses = torch.tensor(
-            padded_responses,
-            dtype=prompt_tokens.dtype,
-            device=cur_device,
-        )
-        sequences = torch.cat([prompt_tokens, padded_responses], dim=-1)
-
-    else:
-
-        policy = actor_critic.model
-        policy.eval()  # type: ignore
-        # Adding a dummy forwards call.
-        # We need this otherwise FSDP throws an error during a standard forward pass.
-        policy( # type: ignore
-            torch.tensor([[0]], dtype=torch.long, device=cur_device),
-            attention_mask=torch.tensor([[1]],
-                                        dtype=torch.bool,
-                                        device=cur_device),
-        )
-
-        # Generate doesn't work if we unpad the FFN. So we need to check if we
-        # need to flip the flag in the model.
-        flipped_usage = flip_pad_token_usage_for_generate(
-            policy,  # type: ignore
-        )
-
-        # We don't need to include EOS tokens since we mask out EOS tokens below
-        generated_dict = policy.generate( # type: ignore
-            prompt_tokens,
-            max_new_tokens=max_gen_len,
-            return_dict_in_generate=True,
-            synced_gpus=True,
-            attention_mask=batch['prompt_attention_mask'],
-            pad_token_id=pad_token_id,
-            **generation_kwargs,
-        )
-
-        # We should flip the flag back after generate as needed.
-        if flipped_usage:
-            flip_pad_token_usage_in_ffn(policy)  # type: ignore
-
-        # Sequences are [batch, seq_len + generated_len], covering the initial prompt and generated values
-        sequences = generated_dict['sequences']  # type: ignore
+    # Sequences are [batch, seq_len + generated_len], covering the initial prompt and generated values
+    sequences = generated_dict['sequences']  # type: ignore
 
     return sequences


### PR DESCRIPTION
This code diff does the following:
- In `_interact_with_env`, 
    - If `vllm_engines` are provided, the batch will be redirected to a newly defined `vllm_generate`. This gathers all prompts, generates everything, and redistributes the generated `sequences` back to each device
    -  Else, it divides the batch by `device_generate_batch_size` and processes through `hf_generate` to get sequences
    - The final sequences are saved in `batch`.
- Later in `env_generate` --> `env_reward`, if `batch` already has `sequences`. These are directly used in reward calculation.
- Also removes the unnecessary list creation in `_resolve_outputs`

Working run: `mcli logs test2-fast-inf-4-gen-8b-math-6k-gen-8k-seq-nokl-fD4UUH -f`