### PR TITLE
GRPO implementation

### DIFF
--- a/compose_rl/ppo/__init__.py
+++ b/compose_rl/ppo/__init__.py
@@ -3,7 +3,11 @@
 
 from compose_rl.ppo.callback import PPOCallback
 from compose_rl.ppo.load_planner import PPOModelLoadPlanner
-from compose_rl.ppo.model import ComposerHFPolicyModel, ComposerMosaicPolicy, ComposerHFCriticFreePolicyModel
+from compose_rl.ppo.model import (
+    ComposerHFCriticFreePolicyModel,
+    ComposerHFPolicyModel,
+    ComposerMosaicPolicy,
+)
 from compose_rl.ppo.modeling_utils import CausalLMOutputWithPastAndValues
 from compose_rl.ppo.policy_configuration import HFPolicyConfig, MPTPolicyConfig
 

--- a/compose_rl/ppo/__init__.py
+++ b/compose_rl/ppo/__init__.py
@@ -3,7 +3,7 @@
 
 from compose_rl.ppo.callback import PPOCallback
 from compose_rl.ppo.load_planner import PPOModelLoadPlanner
-from compose_rl.ppo.model import ComposerHFPolicyModel, ComposerMosaicPolicy
+from compose_rl.ppo.model import ComposerHFPolicyModel, ComposerMosaicPolicy, ComposerHFCriticFreePolicyModel
 from compose_rl.ppo.modeling_utils import CausalLMOutputWithPastAndValues
 from compose_rl.ppo.policy_configuration import HFPolicyConfig, MPTPolicyConfig
 
@@ -11,6 +11,7 @@ __all__ = [
     'PPOCallback',
     'ComposerMosaicPolicy',
     'ComposerHFPolicyModel',
+    'ComposerHFCriticFreePolicyModel',
     'HFPolicyConfig',
     'MPTPolicyConfig',
     'CausalLMOutputWithPastAndValues',

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -226,11 +226,11 @@ def env_reward(
                     if isinstance(value, torch.Tensor) else value
                 for key, value in input_model_kwargs.items()
             }
-            print(f"In Env Reward: {type(actor_critic)=}")
-            print(f"In Env Reward: {type(actor_critic.model)=}")
+            # print(f"In Env Reward: {type(actor_critic)=}")
+            # print(f"In Env Reward: {type(actor_critic.model)=}")
             cur_output = actor_critic(curr_kwargs)
             cur_logits = cur_output['logits']
-            print(f"In Env Reward: {cur_output.keys()=}")
+            # print(f"In Env Reward: {cur_output.keys()=}")
             # need to pull out current actions and prompt len
             cur_actions = curr_kwargs['actions']
             cur_prompt_len = curr_kwargs['prompt_len']

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -337,6 +337,7 @@ class PPOCallback(CallbackWithConfig):
 
         # Which kl estimator to use
         if 'kl_estimator' not in train_config['model']:
+            # TODO: Modify PPO to nuke config_overrides in the future
             # Check in model's config_overrides
             kl_estimator = train_config['model']['config_overrides'].get(
                 'kl_estimator',
@@ -352,6 +353,7 @@ class PPOCallback(CallbackWithConfig):
         self.kl_estimator = kl_estimator
 
         if 'kl_clip_range' not in train_config['model']:
+            # TODO: Modify PPO to nuke config_overrides in the future
             # Check in model's config_overrides
             kl_clip_range = train_config['model']['config_overrides'].get(
                 'kl_clip_range',

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -897,7 +897,6 @@ class PPOCallback(CallbackWithConfig):
             if self.actor_critic.normalize_advantage:
                 grpo_advantage /= (std_rewards + 1e-4)
 
-            env_outs['grpo_rewards'] = rewards
             env_outs['advantages'] = grpo_advantage
             batch_adv_mean = grpo_advantage.mean()
             batch_adv_var = grpo_advantage.var()

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -328,9 +328,9 @@ class PPOCallback(CallbackWithConfig):
         # Other algo specific hparams
         # Find if we are using a critic free model or not
         if train_config['model']['name'] == 'hf_critic_free_lm':
-            self.critic_free_model = True
+            self.critic_free = True
         elif train_config['model']['name'] == 'hf_ppo_lm':
-            self.critic_free_model = False
+            self.critic_free = False
         else:
             raise ValueError(
                 f"Invalid model name: {train_config['model']['name']}. Only hf_critic_free_lm and hf_ppo_lm are supported.",
@@ -845,7 +845,7 @@ class PPOCallback(CallbackWithConfig):
         )
 
         # Now that rewards are resolved, we can compute advantages
-        if not self.critic_free_model:
+        if not self.critic_free:
             env_outs['advantages'] = compute_advantages(
                 rewards=env_outs['rewards'],
                 values=env_outs['values'],
@@ -1062,6 +1062,7 @@ class PPOCallback(CallbackWithConfig):
             self.vllm_engines,
             self.model_update_group,
             batch,
+            critic_free=self.critic_free,
         )
         log.info('Finished broadcasting to vLLM')
         log.info(f'Took: {time.time() - start_time} to broadcast to vllm.')

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -257,10 +257,10 @@ def env_reward(
 
         partial_env_output = {
             'prompt_id': prompt_id,
-            'actions': actions.detach(),
-            'old_log_probs': device_train_microbatch_log_probs.detach(),
-            'old_entropies': device_train_microbatch_entropies.detach(),
-            'obs': right_padded_obs.detach(),
+            'actions': actions,
+            'old_log_probs': device_train_microbatch_log_probs,
+            'old_entropies': device_train_microbatch_entropies,
+            'obs': right_padded_obs,
             'generated_len': generated_len,
             'action_mask': action_mask,
         }
@@ -275,7 +275,7 @@ def env_reward(
                                           dim=-1)
             device_train_microbatch_values *= value_action_mask
             partial_env_output['values'
-                              ] = device_train_microbatch_values.detach()
+                              ] = device_train_microbatch_values
         # Future implementations may change the way reward_seq_len is defined
         # e.g., if special formatting is applied
         reward_seq_len = prompt_len + generated_len
@@ -328,9 +328,9 @@ class PPOCallback(CallbackWithConfig):
         # Other algo specific hparams
         # Find if we are using a critic free model or not
         if train_config['model']['name'] == 'hf_critic_free_lm':
-            self.critic_free = True
+            self.loss_type = "grpo"
         elif train_config['model']['name'] == 'hf_ppo_lm':
-            self.critic_free = False
+            self.loss_type = "ppo"
         else:
             raise ValueError(
                 f"Invalid model name: {train_config['model']['name']}. Only hf_critic_free_lm and hf_ppo_lm are supported.",
@@ -845,7 +845,7 @@ class PPOCallback(CallbackWithConfig):
         )
 
         # Now that rewards are resolved, we can compute advantages
-        if not self.critic_free:
+        if self.loss_type == "ppo":
             env_outs['advantages'] = compute_advantages(
                 rewards=env_outs['rewards'],
                 values=env_outs['values'],
@@ -856,7 +856,7 @@ class PPOCallback(CallbackWithConfig):
                 env_outs['advantages'],
                 env_outs['action_mask'],
             )
-        else:
+        elif self.loss_type == "grpo":
             # compute GRPO advantages
             prompt_id = env_outs['prompt_id']
             rewards = env_outs['rewards']
@@ -900,6 +900,11 @@ class PPOCallback(CallbackWithConfig):
             env_outs['advantages'] = grpo_advantage
             batch_adv_mean = grpo_advantage.mean()
             batch_adv_var = grpo_advantage.var()
+        else:
+            raise ValueError(
+                f'Invalid loss type: {self.loss_type}. ' +
+                'Valid options are: ppo, grpo.',
+            )
 
         mean_ift = masked_mean(
             env_outs['ift_kl'],
@@ -1061,7 +1066,7 @@ class PPOCallback(CallbackWithConfig):
             self.vllm_engines,
             self.model_update_group,
             batch,
-            critic_free=self.critic_free,
+            loss_type=self.loss_type,
         )
         log.info('Finished broadcasting to vLLM')
         log.info(f'Took: {time.time() - start_time} to broadcast to vllm.')

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -272,9 +272,10 @@ def env_reward(
                 action_mask,
                 torch.zeros((batch_size, 1), device=cur_device),
             ],
-                                        dim=-1)
+                                          dim=-1)
             device_train_microbatch_values *= value_action_mask
-            partial_env_output['values'] = device_train_microbatch_values.detach()
+            partial_env_output['values'
+                              ] = device_train_microbatch_values.detach()
         # Future implementations may change the way reward_seq_len is defined
         # e.g., if special formatting is applied
         reward_seq_len = prompt_len + generated_len
@@ -339,7 +340,7 @@ class PPOCallback(CallbackWithConfig):
         if 'kl_estimator' not in train_config['model']:
             # Check in model's config_overrides
             kl_estimator = train_config['model']['config_overrides'].get(
-                'kl_estimator', 
+                'kl_estimator',
                 'k1',
             )
         else:
@@ -864,7 +865,10 @@ class PPOCallback(CallbackWithConfig):
             rewards = utils.masked_sum(rewards, env_outs['action_mask'], dim=-1)
 
             # Get unique prompt IDs and their indices
-            unique_prompt_ids, inverse_indices = torch.unique(prompt_id, return_inverse=True)
+            unique_prompt_ids, inverse_indices = torch.unique(
+                prompt_id,
+                return_inverse=True,
+            )
 
             # Use scatter to compute means and standard deviations
             # First, we'll create a tensor to track counts, sums, and sum of squares
@@ -893,11 +897,10 @@ class PPOCallback(CallbackWithConfig):
             if self.actor_critic.normalize_advantage:
                 grpo_advantage /= (std_rewards + 1e-4)
 
-            env_outs["grpo_rewards"] = rewards
-            env_outs["advantages"] = grpo_advantage
+            env_outs['grpo_rewards'] = rewards
+            env_outs['advantages'] = grpo_advantage
             batch_adv_mean = grpo_advantage.mean()
             batch_adv_var = grpo_advantage.var()
-
 
         mean_ift = masked_mean(
             env_outs['ift_kl'],

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -850,7 +850,11 @@ class PPOCallback(CallbackWithConfig):
             rewards = env_outs['rewards']
 
             # Flatten the rewards by summing on sequence length/action_mask
-            flat_rewards = utils.masked_sum(rewards, env_outs['action_mask'], dim=-1)
+            flat_rewards = utils.masked_sum(
+                rewards,
+                env_outs['action_mask'],
+                dim=-1,
+            )
 
             # Get unique prompt IDs and their indices
             unique_prompt_ids, inverse_indices = torch.unique(
@@ -866,7 +870,11 @@ class PPOCallback(CallbackWithConfig):
             sum_squares = torch.zeros(n_unique, device=prompt_id.device)
 
             # Use scatter_add to accumulate values
-            counts.scatter_add_(0, inverse_indices, torch.ones_like(flat_rewards))
+            counts.scatter_add_(
+                0,
+                inverse_indices,
+                torch.ones_like(flat_rewards),
+            )
             sums.scatter_add_(0, inverse_indices, flat_rewards)
             sum_squares.scatter_add_(0, inverse_indices, flat_rewards**2)
 
@@ -888,8 +896,14 @@ class PPOCallback(CallbackWithConfig):
             # Create advantages of the same shape as original rewards
             advantages = torch.zeros_like(rewards)
             # Copy the flat grpo_advantage according to action_mask
-            expanded_advantages = grpo_advantage.unsqueeze(1).expand_as(env_outs['action_mask'])
-            advantages = torch.where(env_outs['action_mask'].bool(), expanded_advantages, advantages)
+            expanded_advantages = grpo_advantage.unsqueeze(1).expand_as(
+                env_outs['action_mask'],
+            )
+            advantages = torch.where(
+                env_outs['action_mask'].bool(),
+                expanded_advantages,
+                advantages,
+            )
             env_outs['advantages'] = advantages
         else:
             raise ValueError(
@@ -1062,7 +1076,7 @@ class PPOCallback(CallbackWithConfig):
             self.vllm_engines,
             self.model_update_group,
             batch,
-            loss_type=self.actor_critic.loss_type,
+            loss_type=self.actor_critic.loss_type,  # type: ignore
         )
         log.info('Finished broadcasting to vLLM')
         log.info(f'Took: {time.time() - start_time} to broadcast to vllm.')

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -890,7 +890,7 @@ class PPOCallback(CallbackWithConfig):
             # Calculate GRPO advantage
             grpo_advantage = (rewards - mean_rewards)
             # Only normalize the advantage if flag is set
-            if self.actor_critic.advantage_normalization:
+            if self.actor_critic.normalize_advantage:
                 grpo_advantage /= (std_rewards + 1e-4)
 
             env_outs["grpo_rewards"] = rewards

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -326,13 +326,6 @@ class PPOCallback(CallbackWithConfig):
         # Value used in the generalized advantage estimate calculation.
         self.lambda_gae = var_config.get('lambda_gae', 1.0)
 
-        # Which kl estimator to use
-        kl_estimator = train_config['model'].get('kl_estimator', 'k1')
-        if kl_estimator not in ['k1', 'k2', 'k3', 'k3_offpolicy']:
-            raise ValueError(
-                f'Invalid kl estimator: {self.kl_estimator}. ' +
-                'Valid options are: k1, k2, k3, k3_offpolicy.',
-            )
         # Other algo specific hparams
         # Find if we are using a critic free model or not
         if train_config['model']['name'] == 'hf_critic_free_lm':
@@ -344,8 +337,13 @@ class PPOCallback(CallbackWithConfig):
                 f"Invalid model name: {train_config['model']['name']}. Only hf_critic_free_lm and hf_ppo_lm are supported.",
             )
 
-        # Advantage normalization for GRPO. Defaults to True.
-        self.advantage_normalization = var_config.get('advantage_normalization', True)
+        # Which kl estimator to use
+        kl_estimator = train_config['model'].get('kl_estimator', 'k1')
+        if kl_estimator not in ['k1', 'k2', 'k3', 'k3_offpolicy']:
+            raise ValueError(
+                f'Invalid kl estimator: {self.kl_estimator}. ' +
+                'Valid options are: k1, k2, k3, k3_offpolicy.',
+            )
         self.kl_estimator = kl_estimator
 
         kl_clip_range = train_config['model'].get('kl_clip_range', 40.0)
@@ -880,7 +878,7 @@ class PPOCallback(CallbackWithConfig):
             # Borrowing this logic from TRL: https://github.com/huggingface/trl/blob/c82f626f94a83986fd1b28091fac3a0100b51c68/trl/trainer/grpo_trainer.py#L1057C52-L1057C52
             grpo_advantage = (rewards - mean_rewards)
             # Only normalize the advantage if flag is set
-            if self.advantage_normalization:
+            if self.actor_critic.advantage_normalization:
                 grpo_advantage /= (std_rewards + 1e-4)
 
             env_outs["grpo_rewards"] = rewards

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -334,6 +334,16 @@ class PPOCallback(CallbackWithConfig):
                 'Valid options are: k1, k2, k3, k3_offpolicy.',
             )
         # Other algo specific hparams
+        # Find if we are using a critic free model or not
+        if train_config['model']['name'] == 'hf_critic_free_lm':
+            self.critic_free_model = True
+        elif train_config['model']['name'] == 'hf_ppo_lm':
+            self.critic_free_model = False
+        else:
+            raise ValueError(
+                f"Invalid model name: {train_config['model']['name']}. Only hf_critic_free_lm and hf_ppo_lm are supported.",
+            )
+
         # Advantage normalization for GRPO. Defaults to True.
         self.advantage_normalization = var_config.get('advantage_normalization', True)
         self.kl_estimator = kl_estimator
@@ -824,7 +834,7 @@ class PPOCallback(CallbackWithConfig):
         )
 
         # Now that rewards are resolved, we can compute advantages
-        if 'values' in env_outs:
+        if not self.critic_free_model:
             env_outs['advantages'] = compute_advantages(
                 rewards=env_outs['rewards'],
                 values=env_outs['values'],

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -274,8 +274,7 @@ def env_reward(
             ],
                                           dim=-1)
             device_train_microbatch_values *= value_action_mask
-            partial_env_output['values'
-                              ] = device_train_microbatch_values
+            partial_env_output['values'] = device_train_microbatch_values
         # Future implementations may change the way reward_seq_len is defined
         # e.g., if special formatting is applied
         reward_seq_len = prompt_len + generated_len
@@ -328,9 +327,9 @@ class PPOCallback(CallbackWithConfig):
         # Other algo specific hparams
         # Find if we are using a critic free model or not
         if train_config['model']['name'] == 'hf_critic_free_lm':
-            self.loss_type = "grpo"
+            self.loss_type = 'grpo'
         elif train_config['model']['name'] == 'hf_ppo_lm':
-            self.loss_type = "ppo"
+            self.loss_type = 'ppo'
         else:
             raise ValueError(
                 f"Invalid model name: {train_config['model']['name']}. Only hf_critic_free_lm and hf_ppo_lm are supported.",
@@ -845,7 +844,7 @@ class PPOCallback(CallbackWithConfig):
         )
 
         # Now that rewards are resolved, we can compute advantages
-        if self.loss_type == "ppo":
+        if self.loss_type == 'ppo':
             env_outs['advantages'] = compute_advantages(
                 rewards=env_outs['rewards'],
                 values=env_outs['values'],
@@ -856,7 +855,7 @@ class PPOCallback(CallbackWithConfig):
                 env_outs['advantages'],
                 env_outs['action_mask'],
             )
-        elif self.loss_type == "grpo":
+        elif self.loss_type == 'grpo':
             # compute GRPO advantages
             prompt_id = env_outs['prompt_id']
             rewards = env_outs['rewards']

--- a/compose_rl/ppo/generation_utils.py
+++ b/compose_rl/ppo/generation_utils.py
@@ -62,7 +62,7 @@ def hf_generate(
     )
 
     # We don't need to include EOS tokens since we mask out EOS tokens below
-    generated_dict = policy.generate( # type: ignore
+    generated_dict = actor_critic.generate( # type: ignore
         prompt_tokens,
         max_new_tokens=max_gen_len,
         return_dict_in_generate=True,

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -95,7 +95,7 @@ class ComposerMosaicPolicy(HuggingFaceModel):
         return_dict, kl_loss = online_rl_loss(
             outputs=outputs,
             batch=batch,
-            critic_free=False,
+            loss_type='ppo',
             value_clip_range=self.config.value_clip_range,
             value_loss_weight=self.config.value_loss_weight,
             policy_clip_ratio=self.config.policy_clip_ratio,
@@ -206,7 +206,7 @@ class ComposerHFPolicyModel(ComposerHFPolicy):
         return_dict, kl_loss = online_rl_loss(
             outputs=outputs,
             batch=batch,
-            critic_free=False,
+            loss_type='ppo',
             value_clip_range=self.config.value_clip_range,
             value_loss_weight=self.config.value_loss_weight,
             policy_clip_ratio=self.config.policy_clip_ratio,
@@ -269,7 +269,7 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
         ret_val = composer_online_rl_forward(
             batch,
             self.model,
-            critic_free=True,
+            loss_type='grpo',
         )
         return ret_val
 
@@ -282,7 +282,7 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
         return_dict, kl_loss = online_rl_loss(
             outputs=outputs,
             batch=batch,
-            critic_free=True,
+            loss_type='grpo',
             policy_clip_ratio=self.policy_clip_ratio,
             policy_clip_high_ratio=self.policy_clip_high_ratio,
             length_normalize_policy_loss=self.length_normalize_policy_loss,

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -239,11 +239,10 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
     default_eval_metrics: tuple = ()
     def __init__(
         self,
-        advantage_normalization: bool = True,
-        length_normalization: bool = True,
+        normalize_advantage: bool = True,
+        length_normalize_policy_loss: bool = True,
         policy_clip_ratio: float = 0.15,
         policy_clip_high_ratio: float | None = None,
-        length_normalize_policy_loss: bool = True,
         compute_kl_loss: bool = True,
         target_kl: float = 0.1,
         kl_estimator: str = 'k1',
@@ -253,11 +252,10 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
         super().__init__(**kwargs)
         self.policy_kl = []
 
-        self.advantage_normalization = advantage_normalization
-        self.length_normalization = length_normalization
+        self.normalize_advantage = normalize_advantage
+        self.length_normalize_policy_loss = length_normalize_policy_loss
         self.policy_clip_ratio = policy_clip_ratio
         self.policy_clip_high_ratio = policy_clip_high_ratio
-        self.length_normalize_policy_loss = length_normalize_policy_loss
         self.compute_kl_loss = compute_kl_loss
         self.target_kl = target_kl
         self.kl_estimator = kl_estimator

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -23,8 +23,8 @@ from compose_rl.ppo.modeling_hf import ComposerHFPolicy
 from compose_rl.ppo.modeling_mpt import MPTForPolicy
 from compose_rl.ppo.modeling_utils import composer_ppo_forward, ppo_loss
 from compose_rl.ppo.policy_configuration import (
-    HFCriticFreeConfig,
-    HFPolicyConfig,
+    # HFCriticFreeConfig,
+    # HFPolicyConfig,
     MPTPolicyConfig,
 )
 from compose_rl.utils import (
@@ -259,56 +259,6 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
         outputs: MutableMapping,
     ) -> None:
         raise ValueError('Eval forward is not implemented for ComposerHFDPOLM.')
-
-    # @classmethod
-    # def build_config(
-    #     cls,
-    #     pretrained_model_name_or_path: str,
-    #     trust_remote_code: bool,
-    #     use_auth_token: bool,
-    #     attn_implementation: str,
-    #     config_overrides: dict[str, Any],
-    # ) -> PretrainedConfig:
-
-    #     # base_config = AutoConfig.from_pretrained(
-    #     #     pretrained_model_name_or_path,
-    #     #     trust_remote_code=trust_remote_code,
-    #     #     token=use_auth_token,
-    #     #     attn_implementation=attn_implementation,
-    #     #     use_cache=
-    #     #     False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
-    #     #     torch_dtype=config_overrides.get('torch_dtype', 'float32'),
-    #     # )
-
-    #     # print ("base config type is: ", base_config, type(base_config))
-
-    #     # pretrain_cfg = {
-    #     #     'trust_remote_code': trust_remote_code,
-    #     #     'token': use_auth_token,
-    #     # }
-
-    #     # config = HFPolicyConfig(
-    #     #     base_model=pretrained_model_name_or_path,
-    #     #     base_config=base_config,
-    #     #     hidden_size=base_config.hidden_size,
-    #     #     vocab_size=base_config.vocab_size,
-    #     #     pretrain_cfg=pretrain_cfg,
-    #     # )
-
-    #     config = HFCriticFreeConfig.from_pretrained(
-    #         pretrained_model_name_or_path,
-    #         trust_remote_code=trust_remote_code,
-    #         token=use_auth_token,
-    #         attn_implementation=attn_implementation,
-    #         use_cache=
-    #         False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
-    #         torch_dtype=config_overrides.get('torch_dtype', 'float32'),
-    #         policy_clip_ratio=config_overrides.get('policy_clip_ratio', 0.15),
-    #     )
-
-    #     set_config_overrides(config, config_overrides)
-
-    #     return config
 
     def loss(self, outputs: MutableMapping,
              batch: MutableMapping) -> dict[str, torch.Tensor]:

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -10,13 +10,14 @@ from typing import Any, MutableMapping, Optional, Union
 import torch
 from composer.models import HuggingFaceModel
 from composer.utils import dist, is_model_fsdp
-from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, PretrainedConfig, AutoConfig
 
 from llmfoundry.models import ComposerHFCausalLM
+from llmfoundry.utils.config_utils import set_config_overrides  # type: ignore
 from compose_rl.ppo.modeling_hf import ComposerHFPolicy
 from compose_rl.ppo.modeling_mpt import MPTForPolicy
 from compose_rl.ppo.modeling_utils import composer_ppo_forward, ppo_loss
-from compose_rl.ppo.policy_configuration import MPTPolicyConfig
+from compose_rl.ppo.policy_configuration import MPTPolicyConfig, HFPolicyConfig
 from compose_rl.utils import (
     clear_mb_load_balancing_loss,
     get_mb_load_balancing_loss,
@@ -248,7 +249,46 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
     ) -> None:
         raise ValueError('Eval forward is not implemented for ComposerHFDPOLM.')
 
+    @classmethod
+    def build_config(
+        cls,
+        pretrained_model_name_or_path: str,
+        trust_remote_code: bool,
+        use_auth_token: bool,
+        attn_implementation: str,
+        config_overrides: dict[str, Any],
+    ) -> PretrainedConfig:
+
+        base_config = AutoConfig.from_pretrained(
+            pretrained_model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            token=use_auth_token,
+            attn_implementation=attn_implementation,
+            use_cache=
+            False,  # Necessary due to https://github.com/huggingface/transformers/issues/28056
+            torch_dtype=config_overrides.get('torch_dtype', 'float32'),
+        )
+
+        pretrain_cfg = {
+            'trust_remote_code': trust_remote_code,
+            'token': use_auth_token,
+        }
+
+        config = HFPolicyConfig(
+            base_model=pretrained_model_name_or_path,
+            base_config=base_config,
+            hidden_size=base_config.hidden_size,
+            vocab_size=base_config.vocab_size,
+            pretrain_cfg=pretrain_cfg,
+        )
+
+        set_config_overrides(config, config_overrides)
+
+        return config
+
     def loss(self, outputs: MutableMapping, batch: MutableMapping) -> dict[str, torch.Tensor]:
+        print(f'{self.config=}')
+        print(f'{self.model.config=}')
         breakpoint()
         return_dict, kl_loss = grpo_loss(
             outputs,

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -166,7 +166,11 @@ class ComposerHFPolicyModel(ComposerHFPolicy):
         assert isinstance(self.target_kl, float)
 
     def forward(self, batch: MutableMapping):
-        ret_val = composer_online_rl_forward(batch, self.model, loss_type=self.loss_type)
+        ret_val = composer_online_rl_forward(
+            batch,
+            self.model,
+            loss_type=self.loss_type,  # pyright: ignore
+        )
         return ret_val
 
     def generate(self, input_ids: torch.Tensor, *args: Any, **kwargs: Any):
@@ -209,7 +213,7 @@ class ComposerHFPolicyModel(ComposerHFPolicy):
         return_dict, kl_loss = online_rl_loss(
             outputs=outputs,
             batch=batch,
-            loss_type=self.loss_type,
+            loss_type=self.loss_type,  # pyright: ignore
             value_clip_range=self.config.value_clip_range,
             value_loss_weight=self.config.value_loss_weight,
             policy_clip_ratio=self.config.policy_clip_ratio,

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -18,7 +18,10 @@ from transformers import (
 
 from compose_rl.ppo.modeling_hf import ComposerHFPolicy
 from compose_rl.ppo.modeling_mpt import MPTForPolicy
-from compose_rl.ppo.modeling_utils import composer_online_rl_forward, online_rl_loss
+from compose_rl.ppo.modeling_utils import (
+    composer_online_rl_forward,
+    online_rl_loss,
+)
 from compose_rl.ppo.policy_configuration import MPTPolicyConfig
 from compose_rl.utils import (
     clear_mb_load_balancing_loss,
@@ -237,6 +240,7 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
     """HF class wrapper for Critic Free Policy model."""
     default_train_metrics: tuple = ()
     default_eval_metrics: tuple = ()
+
     def __init__(
         self,
         normalize_advantage: bool = True,
@@ -262,16 +266,19 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
         self.kl_clip_range = kl_clip_range
 
     def forward(self, batch: MutableMapping):
-        ret_val = composer_online_rl_forward(batch, self.model, critic_free=True)
+        ret_val = composer_online_rl_forward(
+            batch,
+            self.model,
+            critic_free=True,
+        )
         return ret_val
-    
+
     def eval_forward(self, batch: MutableMapping, outputs: MutableMapping):
         raise ValueError(
             'Eval forward is not supported for HF Critic Free Policy.',
         )
 
-    def loss(self, outputs: MutableMapping,
-             batch: MutableMapping) -> dict[str, torch.Tensor]:
+    def loss(self, outputs: MutableMapping, batch: MutableMapping):
         return_dict, kl_loss = online_rl_loss(
             outputs=outputs,
             batch=batch,

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -244,15 +244,26 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
 
     def __init__(
         self,
+        advantage_normalization: bool = True,
+        length_normalization: bool = True,
         policy_clip_ratio: float = 0.15,
+        compute_kl_loss: bool = True,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.policy_kl = []
 
+        self.advantage_normalization = advantage_normalization
+        self.length_normalization = length_normalization
         self.policy_clip_ratio = policy_clip_ratio
-        print('policy clip ratio is: ', self.policy_clip_ratio)
+        self.compute_kl_loss = compute_kl_loss
 
+    def forward(self, batch: MutableMapping):
+        print(f"In Critic Free forward, {type(self.model)=}")
+        print(f"In Critic Free forward, {self.model.config=}")
+        ret_val = composer_ppo_forward(batch, self.model)
+        return ret_val
+    
     def eval_forward(
         self,
         batch: MutableMapping,
@@ -264,6 +275,10 @@ class ComposerHFCriticFreePolicyModel(ComposerHFCausalLM):
              batch: MutableMapping) -> dict[str, torch.Tensor]:
         print(f'{self.config=}')
         print(f'{self.model.config=}')
+        print(f"In Critic Free loss, {self.advantage_normalization=}")
+        print(f"In Critic Free loss, {self.length_normalization=}")
+        print(f"In Critic Free loss, {self.policy_clip_ratio=}")
+        print(f"In Critic Free loss, {self.compute_kl_loss=}")
         breakpoint()
         return_dict, kl_loss = grpo_loss(
             outputs,

--- a/compose_rl/ppo/modeling_hf.py
+++ b/compose_rl/ppo/modeling_hf.py
@@ -73,6 +73,7 @@ class ComposerHFPolicy(BaseHuggingFaceModel):
         additional_train_metrics: Optional[list] = None,
         additional_eval_metrics: Optional[list] = None,
         should_save_peft_only: bool = False,
+        **kwargs: dict[str, Any],
     ):
         super().__init__(
             pretrained_model_name_or_path,
@@ -94,6 +95,9 @@ class ComposerHFPolicy(BaseHuggingFaceModel):
             should_save_peft_only=should_save_peft_only,
         )
         self.model.config.pretrained = False  # type: ignore
+
+        # TODO: ignoring additional kwargs. Fix this logic after refactoring config overrides
+        self.kwargs = kwargs
 
     @classmethod
     def build_config(

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -346,7 +346,7 @@ def online_rl_loss(
             utils.masked_mean(advantages, batch['action_mask']),
     }
     if loss_type == 'ppo':
-        return_dict.update({  
+        return_dict.update({
             'loss/value_loss':
                 value_loss,
             'value_loss/values':

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -85,15 +85,17 @@ def prepare_critic_values_for_training(
     return values
 
 
-def composer_ppo_forward(
+def composer_online_rl_forward(
     batch: MutableMapping,
     model: torch.nn.Module,
+    critic_free: bool = False,
 ) -> MutableMapping:
     """Forward pass for the Composer PPO model.
 
     Args:
         batch (MutableMapping): The batch to run forward over.
         model (torch.nn.Module): The PPO Actor Critic model to run forwards over.
+        critic_free (bool): Whether to use critic free loss (e.g. GRPO). When ``False``, uses PPO loss.
     """
     model_forward_kwargs = {
         'attention_mask': batch['right_padded_attn_mask'],
@@ -105,11 +107,6 @@ def composer_ppo_forward(
     model_forward_kwargs['max_gen_len'] = batch['max_gen_len']
 
     actor_output = model(batch['obs'], **model_forward_kwargs)
-    # print(f"In composer ppo forward, {type(actor_output)=}")
-    # print(f"In composer ppo forward, {actor_output.keys()=}")
-    # print(f"In composer ppo forward, {hasattr(actor_output, 'values')}")
-    # print(f"In composer ppo forward, {actor_output.values=}")
-    # print(f"In composer ppo forward, {('values' in actor_output)=}")
     
     logits = actor_output.logits
 
@@ -119,221 +116,21 @@ def composer_ppo_forward(
         batch['prompt_len'],
         batch['max_gen_len'],
     )
-    # print(f"In composer ppo forward, {logits.shape=}")
-    # print(f"In composer ppo forward, {batch['actions'].shape=}")
-    # print(f"In composer ppo forward, {batch['prompt_len']=}")
-    # print(f"In composer ppo forward, {batch['max_gen_len']=}")
-    # print(f"In composer ppo forward, {log_prob_outputs.shape=}")
 
     return_dict = {
         'online_log_probs': log_prob_outputs,
         'logits': logits,
     }
 
-    if 'values' in actor_output:
+    if not critic_free:
+        if 'values' not in actor_output:
+            raise ValueError(
+                'The actor output does not contain values. Please check the model.',
+            )
         values = actor_output.values
         return_dict['values'] = values
-    # else:
-    #     print(f"In composer ppo forward, No values found in actor output")
-    
+
     return return_dict
-
-
-def ppo_loss(
-    outputs: MutableMapping,
-    batch: MutableMapping,
-    value_clip_range: float,
-    policy_clip_ratio: float,
-    value_loss_weight: float,
-    add_direct_kl_loss: bool = False,
-    kl_estimator: Optional[str] = 'k1',
-    kl_clip_range: Optional[float] = 40.0,
-) -> tuple[MutableMapping, torch.Tensor]:
-    """Compute the PPO loss.
-
-    Args:
-        outputs (MutableMapping): The outputs from the forward pass.
-        batch (MutableMapping): The batch to compute the loss over.
-        value_clip_range (float): The value clip range.
-        policy_clip_ratio (float): The policy clip ratio.
-        value_loss_weight (float): The value loss weight.
-        add_direct_kl_loss (bool): Whether to add the KL loss directly to the loss. Default: ``False``.
-        kl_estimator (str): The KL estimator to use. Default: ``'k1'``.
-        kl_clip_range (float): The clip range for the KL divergence. Default: ``40.0``.
-    """
-    # v_preds: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
-    # values: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
-    # advantages: [bs, gen_len] advantage computation from ppo
-    # log_probs: [bs, gen_len] log probability of each action
-    # action_mask: [bs, gen_len] action mask
-
-    advantages = batch['advantages']
-    # Note: `values` are the outputs of the critic model at the start of the PPO epoch and are fixed throughout the epoch,
-    # and `v_preds` are the outputs of the critic model using its current weights.
-    # Tensors in `batch` are fixed throughout the PPO epoch, and
-    # tensors in `outputs` are recomputed at the start of each step in the epoch.
-    v_preds = outputs['values'][:, :-1] * batch['action_mask']
-    v_preds = v_preds.to(advantages.dtype)
-
-    values = batch['values'][:, :-1] * batch['action_mask']
-
-    returns = advantages + values
-    returns_mean = utils.masked_mean(returns, batch['action_mask'])
-    returns_var = utils.masked_var(returns, batch['action_mask'])
-
-    v_pred_clipped = torch.clamp(
-        v_preds,
-        values - value_clip_range,
-        values + value_clip_range,
-    )
-
-    value_loss_1 = (v_preds - returns)**2
-    value_loss_2 = (v_pred_clipped - returns)**2
-
-    value_loss = 0.5 * utils.masked_mean(
-        torch.max(value_loss_1, value_loss_2),
-        batch['action_mask'],
-    )
-    value_clip_frac = utils.masked_mean(
-        torch.gt(value_loss_1, value_loss_2).double(),
-        batch['action_mask'],
-    )
-
-    online_log_probs, old_log_probs = outputs['online_log_probs'], batch[
-        'old_log_probs']
-    old_entropies = batch['old_entropies']
-
-    adv_masked_mean = batch['adv_masked_mean']
-    adv_masked_var = batch['adv_masked_var']
-
-    # If adv masked mean isn't just a scalar, then should be duplicated across all dimensions
-    # TODO: add check for the tensor is duplicated, make this into a utils?
-    if adv_masked_mean.dim() > 0:
-        adv_masked_mean = adv_masked_mean[0]
-    if adv_masked_var.dim() > 0:
-        adv_masked_var = adv_masked_var[0]
-
-    # Normalizing advantages over each minibatch
-    advantages = utils.masked_normalize(
-        batch['advantages'],
-        adv_masked_mean,
-        adv_masked_var,
-    )
-    advantages = advantages.detach()
-
-    policy_kl_dict = utils.approx_kl(
-        log_p=online_log_probs,
-        log_q=old_log_probs,
-        kl_clip_range=kl_clip_range,
-    )
-    policy_kl = utils.masked_mean(
-        policy_kl_dict[kl_estimator], # pyright: ignore
-        batch['action_mask'],
-    )
-    online_ift_kl_dict = utils.approx_kl(
-        log_p=batch['ift_log_probs'],
-        log_q=outputs['online_log_probs'],
-        kl_clip_range=kl_clip_range,
-    )
-    online_ift_kl = utils.masked_mean(
-        online_ift_kl_dict[kl_estimator], # pyright: ignore
-        batch['action_mask'],
-    )
-
-    ratio = torch.exp(online_log_probs - old_log_probs)
-    policy_loss_1 = -advantages * ratio
-    policy_loss_2 = -advantages * torch.clamp(
-        ratio,
-        1 - policy_clip_ratio,
-        1 + policy_clip_ratio,
-    )
-
-    policy_loss = torch.max(policy_loss_1, policy_loss_2)
-    policy_clip_frac = utils.masked_mean(
-        torch.gt(policy_loss_1, policy_loss_2).double(),
-        batch['action_mask'],
-    )
-    policy_loss = utils.masked_mean(policy_loss, batch['action_mask'])
-    val_error = utils.masked_mean((v_preds - returns)**2, batch['action_mask'])
-
-    policy_kl_logging_dict = {
-        f'kl/policy_kl_{k}_estimate': v for k, v in policy_kl_dict.items()
-    }
-    online_ift_kl_logging_dict = {
-        f'kl/online_ift_kl_{k}_estimate': v
-        for k, v in online_ift_kl_dict.items()
-    }
-
-    return_dict = {
-        'loss/value_loss': value_loss,
-        'loss/policy_loss': policy_loss,
-        'kl/policy_kl': policy_kl,
-        'kl/online_ift_kl': online_ift_kl,
-        'kl/ift_kl_scalar': batch['ift_kl_scalar'],
-        **policy_kl_logging_dict,
-        **online_ift_kl_logging_dict,
-        'value_loss/clip_frac': value_clip_frac,
-        'policy_loss/clip_frac': policy_clip_frac,
-        'value_loss/returns_mean': returns_mean,
-        'value_loss/returns_var': returns_var,
-        'value_loss/value_error': val_error,
-        'advantages/mean': utils.masked_mean(advantages, batch['action_mask']),
-        'policy_loss/ratio': utils.masked_mean(ratio, batch['action_mask']),
-        'value_loss/values': utils.masked_mean(values, batch['action_mask']),
-        'value_loss/vpred': utils.masked_mean(v_preds, batch['action_mask']),
-        'gen/gen_length': batch['action_mask'].sum(dim=1).to(torch.float32),
-        'gen/entropy': old_entropies,
-    }
-
-    for key, value in batch.items():
-        # This logic handles reward logging a little differently than other quantities.
-        # For rewards shaped as [batch, actions] we log (1) the per-sequence masked average
-        # and (2) the per-sequence masked sum over actions, both size [batch].
-        # We then average over [batch], so the interpretation is (1) the average per-token
-        # reward, and (2) the average total reward.
-        if 'reward' in key:
-            if value.shape == batch['action_mask'].shape:
-                # Average reward per timestep
-                return_dict['env/' + str(key) + '_mean'] = utils.masked_mean(
-                    value,
-                    batch['action_mask'],
-                    dim=1,
-                ).mean(dim=0)
-                # Total reward over timesteps
-                return_dict['env/' + str(key) + '_total'] = utils.masked_sum(
-                    value,
-                    batch['action_mask'],
-                    dim=1,
-                ).mean(dim=0)
-            else:
-                # If this value is not [batch, actions] shaped, just do a
-                # vanilla mean.
-                return_dict['env/' + str(key)] = value.mean(dim=0)
-        if 'ift_kl' == key:
-            return_dict['kl/' + str(key)] = utils.masked_mean(
-                value,
-                batch['action_mask'],
-            )
-
-    # Detaching all values
-    for key, value in return_dict.items():
-        return_dict[key] = value.detach().cpu()
-
-    return_dict['total'] = policy_loss + value_loss_weight * value_loss
-
-    # If we want to directly minimize the KL Divergence, we can do so here
-    # and it will not include the KL in the reward.
-    if add_direct_kl_loss:
-        return_dict['total'] += batch['ift_kl_scalar'][0] * online_ift_kl
-        return_dict['loss/online_ift_kl'] = (
-            batch['ift_kl_scalar'][0] * online_ift_kl
-        )
-
-    if 'lbl' in outputs and outputs['lbl'] is not None:
-        return_dict['loss/lbl'] = outputs['lbl']
-        return_dict['total'] += outputs['lbl']
-
-    return return_dict, policy_kl.detach().cpu()
 
 
 def online_rl_loss(

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -105,8 +105,12 @@ def composer_ppo_forward(
     model_forward_kwargs['max_gen_len'] = batch['max_gen_len']
 
     actor_output = model(batch['obs'], **model_forward_kwargs)
-
-    values = actor_output.values
+    # print(f"In composer ppo forward, {type(actor_output)=}")
+    # print(f"In composer ppo forward, {actor_output.keys()=}")
+    # print(f"In composer ppo forward, {hasattr(actor_output, 'values')}")
+    # print(f"In composer ppo forward, {actor_output.values=}")
+    # print(f"In composer ppo forward, {('values' in actor_output)=}")
+    
     logits = actor_output.logits
 
     log_prob_outputs = utils.get_log_probs(
@@ -115,12 +119,24 @@ def composer_ppo_forward(
         batch['prompt_len'],
         batch['max_gen_len'],
     )
+    print(f"In composer ppo forward, {logits.shape=}")
+    print(f"In composer ppo forward, {batch['actions'].shape=}")
+    print(f"In composer ppo forward, {batch['prompt_len']=}")
+    print(f"In composer ppo forward, {batch['max_gen_len']=}")
+    print(f"In composer ppo forward, {log_prob_outputs.shape=}")
 
-    return {
+    return_dict = {
         'online_log_probs': log_prob_outputs,
         'logits': logits,
-        'values': values,
     }
+
+    if 'values' in actor_output:
+        values = actor_output.values
+        return_dict['values'] = values
+    else:
+        print(f"In composer ppo forward, No values found in actor output")
+    
+    return return_dict
 
 
 def ppo_loss(

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -119,11 +119,11 @@ def composer_ppo_forward(
         batch['prompt_len'],
         batch['max_gen_len'],
     )
-    print(f"In composer ppo forward, {logits.shape=}")
-    print(f"In composer ppo forward, {batch['actions'].shape=}")
-    print(f"In composer ppo forward, {batch['prompt_len']=}")
-    print(f"In composer ppo forward, {batch['max_gen_len']=}")
-    print(f"In composer ppo forward, {log_prob_outputs.shape=}")
+    # print(f"In composer ppo forward, {logits.shape=}")
+    # print(f"In composer ppo forward, {batch['actions'].shape=}")
+    # print(f"In composer ppo forward, {batch['prompt_len']=}")
+    # print(f"In composer ppo forward, {batch['max_gen_len']=}")
+    # print(f"In composer ppo forward, {log_prob_outputs.shape=}")
 
     return_dict = {
         'online_log_probs': log_prob_outputs,
@@ -133,8 +133,8 @@ def composer_ppo_forward(
     if 'values' in actor_output:
         values = actor_output.values
         return_dict['values'] = values
-    else:
-        print(f"In composer ppo forward, No values found in actor output")
+    # else:
+    #     print(f"In composer ppo forward, No values found in actor output")
     
     return return_dict
 

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -334,3 +334,242 @@ def ppo_loss(
         return_dict['total'] += outputs['lbl']
 
     return return_dict, policy_kl.detach().cpu()
+
+
+def online_rl_loss(
+    outputs: MutableMapping,
+    batch: MutableMapping,
+    critic_free: bool,
+    value_clip_range: float = 0.2,
+    value_loss_weight: float = 0.2,
+    policy_clip_ratio: float = 0.15,
+    policy_clip_high_ratio: float | None = None,
+    length_normalize_policy_loss: bool = True,
+    add_direct_kl_loss: bool = False,
+    kl_estimator: Optional[str] = 'k1',
+    kl_clip_range: Optional[float] = 40.0,
+) -> tuple[MutableMapping, torch.Tensor]:
+    """Compute the online RL loss.
+
+    Args:
+        outputs (MutableMapping): The outputs from the forward pass.
+        batch (MutableMapping): The batch to compute the loss over.
+        critic_free (bool): Whether to use critic free loss (e.g. GRPO). When ``False``, uses PPO loss.
+        value_clip_range (float): The value clip range.
+        value_loss_weight (float): The value loss weight.
+        policy_clip_ratio (float): The policy clip ratio.
+        policy_clip_high_ratio (float | None): The high policy clip ratio. Default: ``None``.
+        length_normalize_policy_loss (bool): Whether to normalize the policy loss by the length of the sequence. Default: ``True``.
+        add_direct_kl_loss (bool): Whether to add the KL loss directly to the loss. Default: ``False``.
+        kl_estimator (str): The KL estimator to use. Default: ``'k1'``.
+        kl_clip_range (float): The clip range for the KL divergence. Default: ``40.0``.
+    """
+    # log_probs: [bs, gen_len] log probability of each action
+    # action_mask: [bs, gen_len] action mask
+
+    advantages = batch['advantages']
+    if not critic_free:
+        # advantages: [bs, gen_len] advantage computation from ppo
+        # v_preds: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
+        # values: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
+        # Note: `values` are the outputs of the critic model at the start of the PPO epoch and are fixed throughout the epoch,
+        # and `v_preds` are the outputs of the critic model using its current weights.
+        # Tensors in `batch` are fixed throughout the PPO epoch, and
+        # tensors in `outputs` are recomputed at the start of each step in the epoch.
+        v_preds = outputs['values'][:, :-1] * batch['action_mask']
+        v_preds = v_preds.to(advantages.dtype)
+
+        values = batch['values'][:, :-1] * batch['action_mask']
+
+        returns = advantages + values
+        returns_mean = utils.masked_mean(returns, batch['action_mask'])
+        returns_var = utils.masked_var(returns, batch['action_mask'])
+
+        v_pred_clipped = torch.clamp(
+            v_preds,
+            values - value_clip_range,
+            values + value_clip_range,
+        )
+
+        value_loss_1 = (v_preds - returns)**2
+        value_loss_2 = (v_pred_clipped - returns)**2
+
+        value_loss = 0.5 * utils.masked_mean(
+            torch.max(value_loss_1, value_loss_2),
+            batch['action_mask'],
+        )
+        value_clip_frac = utils.masked_mean(
+            torch.gt(value_loss_1, value_loss_2).double(),
+            batch['action_mask'],
+        )
+
+        val_error = utils.masked_mean((v_preds - returns)**2, batch['action_mask'])
+
+        adv_masked_mean = batch['adv_masked_mean']
+        adv_masked_var = batch['adv_masked_var']
+
+        # If adv masked mean isn't just a scalar, then should be duplicated across all dimensions
+        # TODO: add check for the tensor is duplicated, make this into a utils?
+        if adv_masked_mean.dim() > 0:
+            adv_masked_mean = adv_masked_mean[0]
+        if adv_masked_var.dim() > 0:
+            adv_masked_var = adv_masked_var[0]
+
+        # Normalizing advantages over each minibatch
+        advantages = utils.masked_normalize(
+            batch['advantages'],
+            adv_masked_mean,
+            adv_masked_var,
+        )
+    else:
+        # advantages: [bs] advantage computation from critic free methods like GRPO
+        values = None
+        v_preds = None
+        value_loss = None
+        value_clip_frac = None
+        returns_mean = None
+        returns_var = None
+        val_error = None
+
+    advantages = advantages.detach()
+
+    online_log_probs, old_log_probs = outputs['online_log_probs'], batch[
+        'old_log_probs']
+    old_entropies = batch['old_entropies']
+
+    policy_kl_dict = utils.approx_kl(
+        log_p=online_log_probs,
+        log_q=old_log_probs,
+        kl_clip_range=kl_clip_range,
+    )
+    policy_kl = utils.masked_mean(
+        policy_kl_dict[kl_estimator], # pyright: ignore
+        batch['action_mask'],
+    )
+    online_ift_kl_dict = utils.approx_kl(
+        log_p=batch['ift_log_probs'],
+        log_q=outputs['online_log_probs'],
+        kl_clip_range=kl_clip_range,
+    )
+    online_ift_kl = utils.masked_mean(
+        online_ift_kl_dict[kl_estimator], # pyright: ignore
+        batch['action_mask'],
+    )
+
+    ratio = torch.exp(online_log_probs - old_log_probs)
+    policy_loss_1 = -advantages * ratio
+
+    # Use the same clip ratio for both sides if clip high ratio is not provided
+    if policy_clip_high_ratio is None:
+        policy_clip_high_ratio = policy_clip_ratio
+
+    policy_loss_2 = -advantages * torch.clamp(
+        ratio,
+        1 - policy_clip_ratio,
+        1 + policy_clip_high_ratio,
+    )
+
+    policy_loss = torch.max(policy_loss_1, policy_loss_2)
+    policy_clip_frac = utils.masked_mean(
+        torch.gt(policy_loss_1, policy_loss_2).double(),
+        batch['action_mask'],
+    )
+
+    if length_normalize_policy_loss:
+        policy_loss = utils.masked_mean(policy_loss, batch['action_mask'])
+    else:
+        policy_loss = utils.masked_sum(policy_loss, batch['action_mask'])
+    
+
+    policy_kl_logging_dict = {
+        f'kl/policy_kl_{k}_estimate': v for k, v in policy_kl_dict.items()
+    }
+    online_ift_kl_logging_dict = {
+        f'kl/online_ift_kl_{k}_estimate': v
+        for k, v in online_ift_kl_dict.items()
+    }
+
+    return_dict = {
+        'loss/policy_loss': policy_loss,
+        'kl/policy_kl': policy_kl,
+        'kl/online_ift_kl': online_ift_kl,
+        'kl/ift_kl_scalar': batch['ift_kl_scalar'],
+        **policy_kl_logging_dict,
+        **online_ift_kl_logging_dict,
+        'policy_loss/clip_frac': policy_clip_frac,
+        'policy_loss/ratio': utils.masked_mean(ratio, batch['action_mask']),
+        'gen/gen_length': batch['action_mask'].sum(dim=1).to(torch.float32),
+        'gen/entropy': old_entropies,
+    }
+    if not critic_free:
+        return_dict.update({
+            'advantages/mean': utils.masked_mean(advantages, batch['action_mask']),
+            'loss/value_loss': value_loss,
+            'value_loss/values': utils.masked_mean(values, batch['action_mask']),
+            'value_loss/vpred': utils.masked_mean(v_preds, batch['action_mask']),
+            'value_loss/clip_frac': value_clip_frac,
+            'value_loss/returns_mean': returns_mean,
+            'value_loss/returns_var': returns_var,
+            'value_loss/value_error': val_error,
+        })
+    else:
+        return_dict.update({
+            'advantages/mean': advantages.mean(),
+        })
+
+
+    for key, value in batch.items():
+        # This logic handles reward logging a little differently than other quantities.
+        # For rewards shaped as [batch, actions] we log (1) the per-sequence masked average
+        # and (2) the per-sequence masked sum over actions, both size [batch].
+        # We then average over [batch], so the interpretation is (1) the average per-token
+        # reward, and (2) the average total reward.
+        if 'reward' in key:
+            if value.shape == batch['action_mask'].shape:
+                # Average reward per timestep
+                return_dict['env/' + str(key) + '_mean'] = utils.masked_mean(
+                    value,
+                    batch['action_mask'],
+                    dim=1,
+                ).mean(dim=0)
+                # Total reward over timesteps
+                return_dict['env/' + str(key) + '_total'] = utils.masked_sum(
+                    value,
+                    batch['action_mask'],
+                    dim=1,
+                ).mean(dim=0)
+            else:
+                # If this value is not [batch, actions] shaped, just do a
+                # vanilla mean.
+                return_dict['env/' + str(key)] = value.mean(dim=0)
+        if 'ift_kl' == key:
+            return_dict['kl/' + str(key)] = utils.masked_mean(
+                value,
+                batch['action_mask'],
+            )
+
+    # Detaching all return_dict values
+    for key, value in return_dict.items():
+        return_dict[key] = value.detach().cpu()
+
+    return_dict['total'] = policy_loss
+    if not critic_free:
+        # Add value loss to total loss
+        return_dict['total'] += value_loss_weight * value_loss
+
+    # If we want to directly minimize the KL Divergence, we can do so here
+    # and it will not include the KL in the reward.
+    if add_direct_kl_loss:
+        return_dict['total'] += batch['ift_kl_scalar'][0] * online_ift_kl
+        return_dict['loss/online_ift_kl'] = (
+            batch['ift_kl_scalar'][0] * online_ift_kl
+        )
+
+    if 'lbl' in outputs and outputs['lbl'] is not None:
+        return_dict['loss/lbl'] = outputs['lbl']
+        return_dict['total'] += outputs['lbl']
+
+    return return_dict, policy_kl.detach().cpu()
+
+
+

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -302,59 +302,55 @@ def online_rl_loss(
     #     for k, v in online_ift_kl_dict.items()
     # }
     policy_token_kl_logging_dict = {
-        f'token_kl/policy_token_kl_{k}_estimate': utils.masked_mean(
-            v,
-            batch['action_mask'],
-        )
-        for k, v in policy_kl_dict.items()
+        f'token_kl/policy_token_kl_{k}_estimate':
+            utils.masked_mean(
+                v,
+                batch['action_mask'],
+            ) for k, v in policy_kl_dict.items()
     }
     policy_seq_kl_logging_dict = {
-        f'seq_kl/policy_seq_kl_{k}_estimate': utils.masked_sum(
-            v,
-            batch['action_mask'],
-        )
-        for k, v in policy_kl_dict.items()
+        f'seq_kl/policy_seq_kl_{k}_estimate':
+            utils.masked_sum(
+                v,
+                batch['action_mask'],
+            ) for k, v in policy_kl_dict.items()
     }
     online_ift_token_kl_logging_dict = {
-        f'token_kl/online_ift_token_kl_{k}_estimate': utils.masked_mean(
-            v,
-            batch['action_mask'],
-        )
-        for k, v in online_ift_kl_dict.items()
+        f'token_kl/online_ift_token_kl_{k}_estimate':
+            utils.masked_mean(
+                v,
+                batch['action_mask'],
+            ) for k, v in online_ift_kl_dict.items()
     }
     online_ift_seq_kl_logging_dict = {
-        f'seq_kl/online_ift_seq_kl_{k}_estimate': utils.masked_sum(
-            v,
-            batch['action_mask'],
-        )
-        for k, v in online_ift_kl_dict.items()
+        f'seq_kl/online_ift_seq_kl_{k}_estimate':
+            utils.masked_sum(
+                v,
+                batch['action_mask'],
+            ) for k, v in online_ift_kl_dict.items()
     }
-    # print(f"{online_ift_kl_logging_dict=}")
-    # print(f"{policy_kl_logging_dict=}")
-    # print(f"{policy_token_kl_logging_dict=}")
-    # print(f"{policy_seq_kl_logging_dict=}")
-    # print(f"{online_ift_token_kl_logging_dict=}")
-    # print(f"{online_ift_seq_kl_logging_dict=}")
-    # print(f"{length_normalize_policy_loss=}")
-    # print(f"{policy_kl=}")
-    # print(f"{online_ift_kl=}")
-    # breakpoint()
 
     return_dict = {
-        'loss/policy_loss': policy_loss,
-        'kl/policy_kl': policy_kl,
-        'kl/online_ift_kl': online_ift_kl,
-        'kl/ift_kl_scalar': batch['ift_kl_scalar'],
-        # **policy_kl_logging_dict,
-        # **online_ift_kl_logging_dict,
+        'loss/policy_loss':
+            policy_loss,
+        'kl/policy_kl':
+            policy_kl,
+        'kl/online_ift_kl':
+            online_ift_kl,
+        'kl/ift_kl_scalar':
+            batch['ift_kl_scalar'],
         **policy_token_kl_logging_dict,
         **policy_seq_kl_logging_dict,
         **online_ift_token_kl_logging_dict,
         **online_ift_seq_kl_logging_dict,
-        'policy_loss/clip_frac': policy_clip_frac,
-        'policy_loss/ratio': utils.masked_mean(ratio, batch['action_mask']),
-        'gen/gen_length': batch['action_mask'].sum(dim=1).to(torch.float32),
-        'gen/entropy': old_entropies,
+        'policy_loss/clip_frac':
+            policy_clip_frac,
+        'policy_loss/ratio':
+            utils.masked_mean(ratio, batch['action_mask']),
+        'gen/gen_length':
+            batch['action_mask'].sum(dim=1).to(torch.float32),
+        'gen/entropy':
+            old_entropies,
     }
     if loss_type == 'ppo':
         return_dict.update({

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -362,7 +362,7 @@ def broadcast_to_vllm(
     else:
         # Directly use the model params
         count, num_params = 0, len(
-            list(model.model.named_parameters()),
+            list(model.model.named_parameters()),  # type: ignore
         )
     refss = []
     # This is needed to get the correct model device

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -341,7 +341,7 @@ def broadcast_to_vllm(
     vllm_engines: list,
     model_update_group: Optional[torch.distributed.ProcessGroup],
     batch: dict[str, torch.Tensor],
-    critic_free: bool = False,
+    loss_type: str = "ppo",
 ):
     """Broadcast model weights to all vllm engines.
 
@@ -350,19 +350,23 @@ def broadcast_to_vllm(
         vllm_engines (list): List of vllm engines
         model_update_group (torch.distributed.ProcessGroup): The process group for model updates
         batch (dict[str, torch.Tensor]): The batch to use for the forward pass
-        critic_free (bool): Whether using critic free model for training
+        loss_type (str): The loss type which decides whether to use critic-free or not. Defaults to "ppo".
     """
     # avoid OOM
     torch.cuda.empty_cache()
-    if not critic_free:
+    if loss_type == 'ppo':
         # Extract the lm_backbone params from the model
         count, num_params = 0, len(
             list(model.model.lm_backbone.named_parameters()),  # type: ignore
         )
-    else:
+    elif loss_type == 'grpo':
         # Directly use the model params
         count, num_params = 0, len(
             list(model.model.named_parameters()),  # type: ignore
+        )
+    else:
+        raise ValueError(
+            f'Unsupported loss type: {loss_type}. Supported types are: ppo, grpo',
         )
     refss = []
     # This is needed to get the correct model device

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -341,7 +341,7 @@ def broadcast_to_vllm(
     vllm_engines: list,
     model_update_group: Optional[torch.distributed.ProcessGroup],
     batch: dict[str, torch.Tensor],
-    loss_type: str = "ppo",
+    loss_type: str = 'ppo',
 ):
     """Broadcast model weights to all vllm engines.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ hf_pairwise_rm = "compose_rl.reward_learning:ComposerHFPairwiseRewardModel"
 hf_classifier_rm = "compose_rl.reward_learning:ComposerHFClassifierRewardModel"
 mpt_ppo_lm = "compose_rl.ppo:ComposerMosaicPolicy"
 hf_ppo_lm = "compose_rl.ppo:ComposerHFPolicyModel"
+hf_critic_free_lm = "compose_rl.ppo:ComposerHFCriticFreePolicyModel"
 
 [project.entry-points."llmfoundry_dataloaders"]
 pairwise_preference = "compose_rl.data:build_pairwise_preference_dataloader"

--- a/yamls/local_grpo.yaml
+++ b/yamls/local_grpo.yaml
@@ -80,24 +80,17 @@ variables:
 model:
   <<: *base_model
   name: hf_critic_free_lm
-  advantage_normalization: false
-  length_normalization: false
-  policy_clip_ratio: 0.87
+  normalize_advantage: false
+  length_normalize_policy_loss: false
+  policy_clip_ratio: 0.15
+  policy_clip_high_ratio: 0.28
   compute_kl_loss: true
-  kl_estimator: k5
-  kl_clip_range: -1
+  target_kl: 0.1
+  kl_estimator: k1
+  kl_clip_range: 40.0
 
-  # config_overrides:
-    # critic_dropout: 0.0
-    # value_clip_range: 0.2
-    # value_loss_weight: 0.2
-    # target_kl: 0.1
-
-    # compute_kl_loss: true
 # load_path: # TODO: fill in load path if applicable
 # load_weights_only: true
-# load_ignore_keys:
-# - "state/model/model.critic_head.*"
 # load_strict_model_weights: false
 
 autoresume: true
@@ -122,11 +115,8 @@ tokenizer:
 train_loader:
   name: prompt
   dataset:
-    local: /tmp/train_orl999/
+    # local: # local path
     split: train
-    # remote: s3://data-force-one-datasets/brandon/data/tl_dr_summarization_llama8b_50words/
-    # remote: dbfs:/Volumes/datasets/abhaygupta/rlvr/train/math_orl_8k/
-    remote: dbfs:/Volumes/datasets/abhaygupta/rlvr/train/gsm8k_orl_8b_2k/
     # remote: #
     shuffle: true
     max_gen_len: ${variables.max_gen_len}

--- a/yamls/local_grpo.yaml
+++ b/yamls/local_grpo.yaml
@@ -80,13 +80,14 @@ variables:
 model:
   <<: *base_model
   name: hf_critic_free_lm
-  normalize_advantage: false
-  length_normalize_policy_loss: false
+  loss_type: grpo
+  normalize_advantage: true
+  length_normalize_policy_loss: true
   policy_clip_ratio: 0.15
   policy_clip_high_ratio: 0.28
   compute_kl_loss: true
   target_kl: 0.1
-  kl_estimator: k1
+  kl_estimator: k3
   kl_clip_range: 40.0
 
 # load_path: # TODO: fill in load path if applicable

--- a/yamls/local_grpo_debug.yaml
+++ b/yamls/local_grpo_debug.yaml
@@ -74,16 +74,15 @@ model:
   <<: *base_model
   name: hf_critic_free_lm
 
-  config_overrides:
-    critic_dropout: 0.0
-    value_clip_range: 0.2
-    value_loss_weight: 0.2
-    target_kl: 0.1
+  # config_overrides:
+    # critic_dropout: 0.0
+    # value_clip_range: 0.2
+    # value_loss_weight: 0.2
+    # target_kl: 0.1
 
-    policy_clip_ratio: 0.15
+  policy_clip_ratio: 0.15
 
-    joint_actor_critic: true
-    compute_kl_loss: true
+    # compute_kl_loss: true
 # load_path: # TODO: fill in load path if applicable
 # load_weights_only: true
 # load_ignore_keys:

--- a/yamls/local_grpo_debug.yaml
+++ b/yamls/local_grpo_debug.yaml
@@ -73,14 +73,16 @@ variables:
 model:
   <<: *base_model
   name: hf_critic_free_lm
+  advantage_normalization: false
+  length_normalization: false
+  policy_clip_ratio: 0.87
+  compute_kl_loss: false
 
   # config_overrides:
     # critic_dropout: 0.0
     # value_clip_range: 0.2
     # value_loss_weight: 0.2
     # target_kl: 0.1
-
-  policy_clip_ratio: 0.15
 
     # compute_kl_loss: true
 # load_path: # TODO: fill in load path if applicable

--- a/yamls/local_grpo_debug.yaml
+++ b/yamls/local_grpo_debug.yaml
@@ -1,0 +1,199 @@
+run_name:  # TODO: fill in
+max_seq_len: 2048
+
+variables:
+  tokenizer_name: meta-llama/Llama-3.2-1B-Instruct
+
+  reference_model:
+    model_config: &base_model
+      name: hf_causal_lm
+      pretrained: true
+      use_auth_token: true
+      use_flash_attention_2: true
+      pretrained_model_name_or_path: meta-llama/Llama-3.2-1B-Instruct
+
+    precision: amp_bf16
+
+    # load_path: # TODO: fiill in load path if applicable
+
+  kl_controller:
+    init_kl_coef: 0.01
+    target: 0.2  # We want the KL target to be ~0.2
+    horizon: 12800
+    kl_ctl_type: adaptive
+
+  # The non-train-FSDP config
+  non_train_fsdp_config:
+    sharding_strategy: SHARD_GRAD_OP
+    mixed_precision: DEFAULT
+    activation_checkpointing: true
+    activation_cpu_offload: false
+    verbose: true
+    limit_all_gathers: true
+    state_dict_type: sharded
+    use_orig_params: true
+
+  generation_kwargs:
+    top_p: 1.0
+    top_k: 0
+    use_cache: True
+    temperature: 1.0
+    do_sample: True
+
+  # RL parameters
+  gamma: 1.0
+  lambda_gae: 0.95
+  kl_estimator: k1
+
+  device_generate_batch_size: 32
+
+  epoch_per_iteration: 1
+  num_batches_per_update: 8
+  generations_per_prompt: 4
+
+  max_gen_len: 32
+
+  eos_token_ids:
+  - 128001
+  - 128008
+  - 128009
+
+  rewards:
+    short_response_reward:
+      reward_type: short_response_reward
+      reward: -1.0
+      len_threshold: 5
+
+  buffer:
+    name: MinibatchRolloutBuffer
+    max_buffer_size: ${variables.num_batches_per_update}
+
+  center_reward_mean:
+
+model:
+  <<: *base_model
+  name: hf_critic_free_lm
+
+  config_overrides:
+    critic_dropout: 0.0
+    value_clip_range: 0.2
+    value_loss_weight: 0.2
+    target_kl: 0.1
+
+    policy_clip_ratio: 0.15
+
+    joint_actor_critic: true
+    compute_kl_loss: true
+# load_path: # TODO: fill in load path if applicable
+# load_weights_only: true
+# load_ignore_keys:
+# - "state/model/model.critic_head.*"
+# load_strict_model_weights: false
+
+autoresume: true
+
+algorithms:
+  gradient_clipping:
+    clipping_threshold: 1.0
+    clipping_type: norm
+
+dist_timeout: 1000
+
+# Tokenizer
+tokenizer:
+  name: ${variables.tokenizer_name}
+  kwargs:
+    model_max_length: ${max_seq_len}
+    padding_side: left
+    trust_remote_code: true
+    padding: "longest"
+    truncation: true
+
+train_loader:
+  name: prompt
+  dataset:
+    local: /tmp/train_orl999/
+    split: train
+    # remote: s3://data-force-one-datasets/brandon/data/tl_dr_summarization_llama8b_50words/
+    # remote: dbfs:/Volumes/datasets/abhaygupta/rlvr/train/math_orl_8k/
+    remote: dbfs:/Volumes/datasets/abhaygupta/rlvr/train/gsm8k_orl_8b_2k/
+    # remote: #
+    shuffle: true
+    max_gen_len: ${variables.max_gen_len}
+    max_seq_len: ${max_seq_len}
+    predownload: 1000
+    shuffle_seed: ${seed}
+    download_timeout: 60
+  drop_last: true
+  num_workers: 8
+
+optimizer:
+  name: decoupled_adamw
+  lr: 5.0e-6
+  betas:
+  - 0.9
+  - 0.95
+  eps: 1.0e-9
+  weight_decay: 1.0e-7
+
+scheduler:
+  name: constant_with_warmup
+  t_warmup: 0ba
+  t_max: 12800ep
+
+global_train_batch_size: 32
+device_train_microbatch_size: 1
+device_eval_batch_size: 1
+
+max_duration: 10iter
+eval_interval: 1
+eval_subset_num_batches: -1
+eval_first: false
+
+# System
+seed: 17
+precision: amp_bf16
+
+# FSDP
+fsdp_config:
+  sharding_strategy: SHARD_GRAD_OP
+  mixed_precision: DEFAULT
+  activation_checkpointing: true
+  activation_cpu_offload: false
+  verbose: true
+  limit_all_gathers: true
+  state_dict_type: sharded
+  use_orig_params: true
+
+# Logging
+progress_bar: false
+log_to_console: true
+console_log_interval: 1ba
+
+callbacks:
+  speed_monitor:
+    window_size: 10
+  lr_monitor: {}
+  memory_monitor: {}
+
+  # hf_checkpointer:
+  # save_folder: # TODO: add save path for the hf checkpoint
+  # save_interval: 10iter
+
+  ppo: {}
+
+save_folder: /tmp/ppo_models   # TODO: fill in with an appropriate value
+# only_composer_checkpoint: true
+# save_weights_only: false
+
+save_interval: 2iter
+save_overwrite: True
+python_log_level: debug
+
+# loggers:
+#   mlflow:
+#     tags:
+#       run:
+#     tracking_uri:
+#     experiment_name:
+#   wandb: {}

--- a/yamls/local_grpo_debug.yaml
+++ b/yamls/local_grpo_debug.yaml
@@ -181,7 +181,7 @@ callbacks:
 
   ppo: {}
 
-save_folder: /tmp/ppo_models   # TODO: fill in with an appropriate value
+save_folder: /tmp/critic_free_models   # TODO: fill in with an appropriate value
 # only_composer_checkpoint: true
 # save_weights_only: false
 

--- a/yamls/local_grpo_debug.yaml
+++ b/yamls/local_grpo_debug.yaml
@@ -84,8 +84,8 @@ model:
   length_normalization: false
   policy_clip_ratio: 0.87
   compute_kl_loss: true
-  # kl_estimator: k3
-  # kl_clip_range: 40.0
+  kl_estimator: k5
+  kl_clip_range: -1
 
   # config_overrides:
     # critic_dropout: 0.0
@@ -192,7 +192,7 @@ callbacks:
 
   ppo: {}
 
-save_folder: /tmp/critic_free_models2   # TODO: fill in with an appropriate value
+save_folder: /tmp/critic_free_models   # TODO: fill in with an appropriate value
 # only_composer_checkpoint: true
 # save_weights_only: false
 

--- a/yamls/local_grpo_debug.yaml
+++ b/yamls/local_grpo_debug.yaml
@@ -43,7 +43,7 @@ variables:
   # RL parameters
   gamma: 1.0
   lambda_gae: 0.95
-  kl_estimator: k1
+  # kl_estimator: k1
 
   device_generate_batch_size: 32
 
@@ -59,14 +59,21 @@ variables:
   - 128009
 
   rewards:
-    short_response_reward:
+    bad_generation_end:
+      reward: -3
+      eos_penalty: true
+      reward_type: bad_generation_end
+    math_verifier:
+      reward_type: math_verifier
+      reward: 2
+    penalize_extra_short_responses:
+      reward: -1
       reward_type: short_response_reward
-      reward: -1.0
-      len_threshold: 5
+      len_threshold: 10
 
   buffer:
     name: MinibatchRolloutBuffer
-    max_buffer_size: ${variables.num_batches_per_update}
+    # max_buffer_size: ${variables.num_batches_per_update}
 
   center_reward_mean:
 
@@ -76,7 +83,9 @@ model:
   advantage_normalization: false
   length_normalization: false
   policy_clip_ratio: 0.87
-  compute_kl_loss: false
+  compute_kl_loss: true
+  # kl_estimator: k3
+  # kl_clip_range: 40.0
 
   # config_overrides:
     # critic_dropout: 0.0
@@ -147,7 +156,7 @@ device_train_microbatch_size: 1
 device_eval_batch_size: 1
 
 max_duration: 10iter
-eval_interval: 1
+eval_interval: -1
 eval_subset_num_batches: -1
 eval_first: false
 
@@ -183,7 +192,7 @@ callbacks:
 
   ppo: {}
 
-save_folder: /tmp/critic_free_models   # TODO: fill in with an appropriate value
+save_folder: /tmp/critic_free_models2   # TODO: fill in with an appropriate value
 # only_composer_checkpoint: true
 # save_weights_only: false
 

--- a/yamls/local_ppo.yaml
+++ b/yamls/local_ppo.yaml
@@ -72,7 +72,7 @@ variables:
 model:
   <<: *base_model
   name: hf_ppo_lm
-
+  loss_type: ppo
   config_overrides:
     critic_dropout: 0.0
     value_clip_range: 0.2

--- a/yamls/local_ppo.yaml
+++ b/yamls/local_ppo.yaml
@@ -83,7 +83,7 @@ model:
 
     joint_actor_critic: true
     compute_kl_loss: true
-    kl_estimator: k1
+    kl_estimator: k3
     kl_clip_range: 40.0
 
 # load_path: # TODO: fill in load path if applicable


### PR DESCRIPTION
Adds critic free model pathway to online RL code (for [GRPO](https://arxiv.org/abs/2402.03300)) and modifies some function signatures and code pathways.
- new `hf_critic_free_lm` model class similar to DPO HF model (i.e. doesn't have `config_overrides` but directly passes additional params via model_config)
- Includes `normalize_advantage` and `length_normalize_policy_loss` flags for critic-free model. Set these both to `false` for [Dr. GRPO objective](https://arxiv.org/abs/2503.20783). The `length_normalize_policy_loss` also modifies KL length normalization.
- `ppo_loss` --> `online_rl_loss`. Shared pathway for both ppo and grpo with `critic_free` boolean flag
- `composer_ppo_forward` --> `composer_online_rl_forward`. Shared pathway for both ppo and grpo with `critic_free` path
- Logs both `seq_kl` and `token_kl` of all variants in the loss logs

Working runs with new patch:
- GRPO `mcli logs test-critic-free-pr-grpo-kl-fix-CcXvGF -f`
- PPO `mcli logs test-critic-free-pr-ppo-kl-fix-sXRGBT -f`

NOTE: Need to modify the PPO model definition to nuke `config_overrides` in the future

Autoresumption also working with GRPO
<img width="372" alt="image" src="https://github.com/user-attachments/assets/f1ad3794-7c27-47e8-b3f2-838feb584c01" />
