### PR TITLE
Unified kl estimators 

### DIFF
--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -10,7 +10,7 @@ import os
 import socket
 import time
 from itertools import chain
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import ray
 import torch
@@ -70,7 +70,8 @@ def env_reward(
     device_train_microbatch_size: int,
     tokenizer: Tokenizer,
     eos_token_ids: list[int],
-    kl_estimator: str,
+    kl_estimator: Optional[str] = 'k1',
+    kl_clip_range: Optional[float] = None,
 ) -> tuple[
     dict[str, torch.Tensor],
     list[tuple[str, str]],
@@ -93,6 +94,7 @@ def env_reward(
         tokenizer (Tokenizer): The actor critic's tokenizer.
         eos_token_ids (list[int]): A list of eos token ids.
         kl_estimator (str): Which kl estimator to use. Options are 'k1', 'k2', 'k3' and 'k3_offpolicy'.
+        kl_clip_range (float): The clip range for the KL divergence.
 
     Returns:
         partial_env_output (dict[str, tensor]): Partially complete dictionary of return elements suitable
@@ -286,6 +288,7 @@ def env_reward(
             action_log_probs=device_train_microbatch_log_probs,
             device_train_microbatch_size=device_train_microbatch_size,
             kl_estimator=kl_estimator,
+            kl_clip_range=kl_clip_range,
             verified_answers=verified_answers,
         )
 
@@ -319,17 +322,13 @@ class PPOCallback(CallbackWithConfig):
         self.lambda_gae = var_config.get('lambda_gae', 1.0)
 
         # Which kl estimator to use
-        self.kl_estimator = train_config.get('model',
-                                             {}).get('kl_estimator', 'k1')
-        if self.kl_estimator is None:
-            raise ValueError(
-                'kl_estimator must be specified in the model section of the train_config',
-            )
+        self.kl_estimator = train_config['model'].get('kl_estimator', 'k1')
         if self.kl_estimator not in ['k1', 'k2', 'k3', 'k3_offpolicy']:
             raise ValueError(
                 f'Invalid kl estimator: {self.kl_estimator}. ' +
                 'Valid options are: k1, k2, k3, k3_offpolicy.',
             )
+        self.kl_clip_range = train_config['model'].get('kl_clip_range', None)
 
         # Generation keyword arguments.
         self.generation_kwargs = var_config.get('generation_kwargs')
@@ -708,6 +707,7 @@ class PPOCallback(CallbackWithConfig):
             tokenizer=self.tokenizer,  # type: ignore
             eos_token_ids=self.eos_token_ids,  # type: ignore
             kl_estimator=self.kl_estimator,
+            kl_clip_range=self.kl_clip_range,
         )
 
         self.prompts_and_gens.extend(prompts_and_gens)

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -317,8 +317,14 @@ class PPOCallback(CallbackWithConfig):
         self.gamma = var_config.get('gamma', 1.0)
         # Value used in the generalized advantage estimate calculation.
         self.lambda_gae = var_config.get('lambda_gae', 1.0)
+
         # Which kl estimator to use
-        self.kl_estimator = var_config.get('kl_estimator', 'k1')
+        self.kl_estimator = train_config.get('model',
+                                             {}).get('kl_estimator', 'k1')
+        if self.kl_estimator is None:
+            raise ValueError(
+                'kl_estimator must be specified in the model section of the train_config',
+            )
         if self.kl_estimator not in ['k1', 'k2', 'k3', 'k3_offpolicy']:
             raise ValueError(
                 f'Invalid kl estimator: {self.kl_estimator}. ' +

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -71,7 +71,7 @@ def env_reward(
     tokenizer: Tokenizer,
     eos_token_ids: list[int],
     kl_estimator: Optional[str] = 'k1',
-    kl_clip_range: Optional[float] = None,
+    kl_clip_range: Optional[float] = 40.0,
 ) -> tuple[
     dict[str, torch.Tensor],
     list[tuple[str, str]],
@@ -322,13 +322,28 @@ class PPOCallback(CallbackWithConfig):
         self.lambda_gae = var_config.get('lambda_gae', 1.0)
 
         # Which kl estimator to use
-        self.kl_estimator = train_config['model'].get('kl_estimator', 'k1')
-        if self.kl_estimator not in ['k1', 'k2', 'k3', 'k3_offpolicy']:
+        kl_estimator = train_config['model'].get('kl_estimator', 'k1')
+        if kl_estimator not in ['k1', 'k2', 'k3', 'k3_offpolicy']:
             raise ValueError(
                 f'Invalid kl estimator: {self.kl_estimator}. ' +
                 'Valid options are: k1, k2, k3, k3_offpolicy.',
             )
-        self.kl_clip_range = train_config['model'].get('kl_clip_range', None)
+        self.kl_estimator = kl_estimator
+
+        kl_clip_range = train_config['model'].get('kl_clip_range', 40.0)
+        if kl_clip_range <= 0:
+            raise ValueError(
+                f'Invalid kl clip range: {self.kl_clip_range}. ' +
+                'Must be greater than 0.',
+            )
+        # check for precision and clip range
+        precision = train_config['precision']
+        if precision != 'fp32':
+            if kl_clip_range > 50.0:
+                log.warning(
+                    f'Clip value of {kl_clip_range=} will not be effective with {precision=} as range for tensors is too small',
+                )
+        self.kl_clip_range = kl_clip_range
 
         # Generation keyword arguments.
         self.generation_kwargs = var_config.get('generation_kwargs')

--- a/compose_rl/ppo/hf_utils.py
+++ b/compose_rl/ppo/hf_utils.py
@@ -158,7 +158,8 @@ class AutoModelForCausalLMAsPolicy(PreTrainedModel):
         target_kl: float = 0.1,
         policy_clip_ratio: float = 0.15,
         compute_kl_loss: bool = True,
-        kl_estimator: str = 'k1',
+        kl_estimator: Optional[str] = 'k1',
+        kl_clip_range: Optional[float] = 40.0,
         config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
         cache_dir: Optional[Union[str, os.PathLike]] = None,
         ignore_mismatched_sizes: bool = False,
@@ -222,6 +223,7 @@ class AutoModelForCausalLMAsPolicy(PreTrainedModel):
             policy_clip_ratio=policy_clip_ratio,
             compute_kl_loss=compute_kl_loss,
             kl_estimator=kl_estimator,
+            kl_clip_range=kl_clip_range,
         )
 
         model = cls(policy_config)

--- a/compose_rl/ppo/hf_utils.py
+++ b/compose_rl/ppo/hf_utils.py
@@ -158,6 +158,7 @@ class AutoModelForCausalLMAsPolicy(PreTrainedModel):
         target_kl: float = 0.1,
         policy_clip_ratio: float = 0.15,
         compute_kl_loss: bool = True,
+        kl_estimator: str = 'k1',
         config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
         cache_dir: Optional[Union[str, os.PathLike]] = None,
         ignore_mismatched_sizes: bool = False,
@@ -220,6 +221,7 @@ class AutoModelForCausalLMAsPolicy(PreTrainedModel):
             target_kl=target_kl,
             policy_clip_ratio=policy_clip_ratio,
             compute_kl_loss=compute_kl_loss,
+            kl_estimator=kl_estimator,
         )
 
         model = cls(policy_config)

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -93,6 +93,7 @@ class ComposerMosaicPolicy(HuggingFaceModel):
             self.config.policy_clip_ratio,
             self.config.value_loss_weight,
             self.compute_kl_loss,  # pyright: ignore
+            self.config.kl_estimator,
         )
 
         self.policy_kl.append(kl_loss)
@@ -201,6 +202,7 @@ class ComposerHFPolicyModel(ComposerHFPolicy):
             self.config.policy_clip_ratio,
             self.config.value_loss_weight,
             self.compute_kl_loss,  # pyright: ignore
+            self.config.kl_estimator,
         )
 
         self.policy_kl.append(kl_loss)

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -94,6 +94,7 @@ class ComposerMosaicPolicy(HuggingFaceModel):
             self.config.value_loss_weight,
             self.compute_kl_loss,  # pyright: ignore
             self.config.kl_estimator,
+            self.config.kl_clip_range,
         )
 
         self.policy_kl.append(kl_loss)
@@ -203,6 +204,7 @@ class ComposerHFPolicyModel(ComposerHFPolicy):
             self.config.value_loss_weight,
             self.compute_kl_loss,  # pyright: ignore
             self.config.kl_estimator,
+            self.config.kl_clip_range,
         )
 
         self.policy_kl.append(kl_loss)

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -130,6 +130,7 @@ def ppo_loss(
     policy_clip_ratio: float,
     value_loss_weight: float,
     add_direct_kl_loss: bool = False,
+    kl_estimator: str = 'k1',
 ) -> tuple[MutableMapping, torch.Tensor]:
     """Compute the PPO loss.
 
@@ -140,6 +141,7 @@ def ppo_loss(
         policy_clip_ratio (float): The policy clip ratio.
         value_loss_weight (float): The value loss weight.
         add_direct_kl_loss (bool): Whether to add the KL loss directly to the loss. Default: ``False``.
+        kl_estimator (str): The KL estimator to use. Default: ``'k1'``.
     """
     # v_preds: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
     # values: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
@@ -201,17 +203,22 @@ def ppo_loss(
     )
     advantages = advantages.detach()
 
-    policy_kl = utils.masked_mean(
-        utils.approx_kl(online_log_probs, old_log_probs),
-        batch['action_mask'],
+    policy_kl_dict = utils.approx_kl(
+        log_p=online_log_probs,
+        log_q=old_log_probs,
+    )
+    # harcoding this for now, need to confirm with bcui
+    policy_kl = utils.masked_mean(policy_kl_dict['k3'], batch['action_mask'])
+    online_ift_kl_dict = utils.approx_kl(
+        log_p=batch['ift_log_probs'],
+        log_q=outputs['online_log_probs'],
     )
     online_ift_kl = utils.masked_mean(
-        outputs['online_log_probs'] - batch['ift_log_probs'],
+        online_ift_kl_dict[kl_estimator],
         batch['action_mask'],
     )
 
     ratio = torch.exp(online_log_probs - old_log_probs)
-
     policy_loss_1 = -advantages * ratio
     policy_loss_2 = -advantages * torch.clamp(
         ratio,
@@ -224,19 +231,27 @@ def ppo_loss(
         torch.gt(policy_loss_1, policy_loss_2).double(),
         batch['action_mask'],
     )
-
     policy_loss = utils.masked_mean(policy_loss, batch['action_mask'])
-
     val_error = utils.masked_mean((v_preds - returns)**2, batch['action_mask'])
+
+    policy_kl_logging_dict = {
+        f'kl/policy_kl_{k}_estimate': v for k, v in policy_kl_dict.items()
+    }
+    online_ift_kl_logging_dict = {
+        f'kl/online_ift_kl_{k}_estimate': v
+        for k, v in online_ift_kl_dict.items()
+    }
 
     return_dict = {
         'loss/value_loss': value_loss,
         'loss/policy_loss': policy_loss,
         'kl/policy_kl': policy_kl,
+        'kl/online_ift_kl': online_ift_kl,
         'kl/ift_kl_scalar': batch['ift_kl_scalar'],
+        **policy_kl_logging_dict,
+        **online_ift_kl_logging_dict,
         'value_loss/clip_frac': value_clip_frac,
         'policy_loss/clip_frac': policy_clip_frac,
-        'kl/online_ift_kl': online_ift_kl,
         'value_loss/returns_mean': returns_mean,
         'value_loss/returns_var': returns_var,
         'value_loss/value_error': val_error,

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -130,7 +130,8 @@ def ppo_loss(
     policy_clip_ratio: float,
     value_loss_weight: float,
     add_direct_kl_loss: bool = False,
-    kl_estimator: str = 'k1',
+    kl_estimator: Optional[str] = 'k1',
+    kl_clip_range: Optional[float] = 40.0,
 ) -> tuple[MutableMapping, torch.Tensor]:
     """Compute the PPO loss.
 
@@ -142,6 +143,7 @@ def ppo_loss(
         value_loss_weight (float): The value loss weight.
         add_direct_kl_loss (bool): Whether to add the KL loss directly to the loss. Default: ``False``.
         kl_estimator (str): The KL estimator to use. Default: ``'k1'``.
+        kl_clip_range (float): The clip range for the KL divergence. Default: ``40.0``.
     """
     # v_preds: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
     # values: [bs, gen_len + 1] maps each sequence to a scalar. With zero padding
@@ -206,17 +208,19 @@ def ppo_loss(
     policy_kl_dict = utils.approx_kl(
         log_p=online_log_probs,
         log_q=old_log_probs,
+        kl_clip_range=kl_clip_range,
     )
     policy_kl = utils.masked_mean(
-        policy_kl_dict[kl_estimator],
+        policy_kl_dict[kl_estimator], # pyright: ignore
         batch['action_mask'],
     )
     online_ift_kl_dict = utils.approx_kl(
         log_p=batch['ift_log_probs'],
         log_q=outputs['online_log_probs'],
+        kl_clip_range=kl_clip_range,
     )
     online_ift_kl = utils.masked_mean(
-        online_ift_kl_dict[kl_estimator],
+        online_ift_kl_dict[kl_estimator], # pyright: ignore
         batch['action_mask'],
     )
 

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -207,8 +207,10 @@ def ppo_loss(
         log_p=online_log_probs,
         log_q=old_log_probs,
     )
-    # harcoding this for now, need to confirm with bcui
-    policy_kl = utils.masked_mean(policy_kl_dict['k3'], batch['action_mask'])
+    policy_kl = utils.masked_mean(
+        policy_kl_dict[kl_estimator],
+        batch['action_mask'],
+    )
     online_ift_kl_dict = utils.approx_kl(
         log_p=batch['ift_log_probs'],
         log_q=outputs['online_log_probs'],

--- a/compose_rl/ppo/policy_configuration.py
+++ b/compose_rl/ppo/policy_configuration.py
@@ -23,7 +23,8 @@ class MPTPolicyConfig(MPTConfig):
         target_kl: float = 0.1,
         policy_clip_ratio: float = 0.15,
         compute_kl_loss: bool = True,
-        kl_estimator: str = 'k1',
+        kl_estimator: Optional[str] = 'k1',
+        kl_clip_range: Optional[float] = 40.0,
         **kwargs: Any,
     ):
         """Config Class for MPTPolicy.
@@ -39,6 +40,7 @@ class MPTPolicyConfig(MPTConfig):
             compute_kl_loss (bool): Whether to compute the KL divergence loss in the policy as a distillaiton loss.
                 Otherwise we will compute it as an auxiliary reward.
             kl_estimator (str): The KL estimator to use.
+            kl_clip_range (float): The clip range for the KL divergence.
             **kwargs (Any): Additional keyword arguments.
         """
         if not joint_actor_critic:
@@ -54,6 +56,7 @@ class MPTPolicyConfig(MPTConfig):
         self.policy_clip_ratio = policy_clip_ratio
         self.compute_kl_loss = compute_kl_loss
         self.kl_estimator = kl_estimator
+        self.kl_clip_range = kl_clip_range
         super().__init__(**kwargs)
 
 
@@ -74,7 +77,8 @@ class HFPolicyConfig(PretrainedConfig):
         target_kl: float = 0.1,
         policy_clip_ratio: float = 0.15,
         compute_kl_loss: bool = True,
-        kl_estimator: str = 'k1',
+        kl_estimator: Optional[str] = 'k1',
+        kl_clip_range: Optional[float] = 40.0,
         **kwargs: Any,
     ):
         """Config Class for HFPolicy."""
@@ -108,3 +112,4 @@ class HFPolicyConfig(PretrainedConfig):
         self.policy_clip_ratio = policy_clip_ratio
         self.compute_kl_loss = compute_kl_loss
         self.kl_estimator = kl_estimator
+        self.kl_clip_range = kl_clip_range

--- a/compose_rl/ppo/policy_configuration.py
+++ b/compose_rl/ppo/policy_configuration.py
@@ -23,6 +23,7 @@ class MPTPolicyConfig(MPTConfig):
         target_kl: float = 0.1,
         policy_clip_ratio: float = 0.15,
         compute_kl_loss: bool = True,
+        kl_estimator: str = 'k1',
         **kwargs: Any,
     ):
         """Config Class for MPTPolicy.
@@ -37,6 +38,7 @@ class MPTPolicyConfig(MPTConfig):
             policy_clip_ratio (float): Clipping range for the policy.
             compute_kl_loss (bool): Whether to compute the KL divergence loss in the policy as a distillaiton loss.
                 Otherwise we will compute it as an auxiliary reward.
+            kl_estimator (str): The KL estimator to use.
             **kwargs (Any): Additional keyword arguments.
         """
         if not joint_actor_critic:
@@ -51,7 +53,7 @@ class MPTPolicyConfig(MPTConfig):
         self.target_kl = target_kl
         self.policy_clip_ratio = policy_clip_ratio
         self.compute_kl_loss = compute_kl_loss
-
+        self.kl_estimator = kl_estimator
         super().__init__(**kwargs)
 
 
@@ -72,6 +74,7 @@ class HFPolicyConfig(PretrainedConfig):
         target_kl: float = 0.1,
         policy_clip_ratio: float = 0.15,
         compute_kl_loss: bool = True,
+        kl_estimator: str = 'k1',
         **kwargs: Any,
     ):
         """Config Class for HFPolicy."""
@@ -104,3 +107,4 @@ class HFPolicyConfig(PretrainedConfig):
         self.target_kl = target_kl
         self.policy_clip_ratio = policy_clip_ratio
         self.compute_kl_loss = compute_kl_loss
+        self.kl_estimator = kl_estimator

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -303,7 +303,7 @@ class RewardManager:
         action_log_probs: torch.Tensor,
         device_train_microbatch_size: int,
         kl_estimator: Optional[str] = 'k1',
-        kl_clip_range: Optional[float] = None,
+        kl_clip_range: Optional[float] = 40.0,
         verified_answers: Optional[list[str]] = None,
     ) -> tuple[ReferenceOutput, RewardOutput]:
         """Collect rewards for generations.
@@ -490,7 +490,7 @@ class RewardManager:
         batch: MutableMapping,
         device_train_microbatch_size: int,
         kl_estimator: Optional[str] = 'k1',
-        kl_clip_range: Optional[float] = None,
+        kl_clip_range: Optional[float] = 40.0,
     ) -> ReferenceOutput:
         """Computes the reference KL for a batch of data.
 

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -29,6 +29,7 @@ from compose_rl.reward_learning import (
     RewardModel,
 )
 from compose_rl.utils import (
+    approx_kl,
     batch_process_fine_granularities,
     get_log_probs,
     scatter_gather_rewards,
@@ -513,28 +514,11 @@ class RewardManager:
                 max_gen_len=curr_batch['max_gen_len'],
             )
 
-            logprob_diff = (
-                curr_batch['action_log_probs'] - curr_ref_log_probs
-            ).clamp(min=-40.0, max=40.0)
-            approxkl_k1 = logprob_diff
-            approxkl_k2 = 0.5 * (logprob_diff**2)
-            approxkl_k3 = torch.expm1(-logprob_diff) + logprob_diff
-            approxkl_k3_offpolicy = 1.0 - torch.exp(-logprob_diff)
-
-            curr_kl = 0.0
-            if kl_estimator == 'k1':
-                curr_kl = approxkl_k1
-            elif kl_estimator == 'k2':
-                # The k2_loss is approximately equivalent to the one-step KL divergence penalty with the k1 estimator
-                # used in https://arxiv.org/pdf/2310.10505.
-                curr_kl = approxkl_k2
-            elif kl_estimator == 'k3':
-                # The k3 estimator is the non negative kl approximation in http://joschu.net/blog/kl-approx.html
-                curr_kl = approxkl_k3
-            elif kl_estimator == 'k3_offpolicy':
-                # This is taken from https://hongyuzang.notion.site/The-critical-implementation-detail-of-KL-loss-in-GRPO-1ae3fe2c1ff9809a9307c5402e190373
-                # This is specifically for off-policy learning and can be useful for async training.
-                curr_kl = approxkl_k3_offpolicy
+            kl_dict = approx_kl(
+                log_p=curr_ref_log_probs,
+                log_q=curr_batch['action_log_probs'],
+            )
+            curr_kl = kl_dict[kl_estimator]
 
             kl.append(curr_kl)
             ref_model_log_probs.append(curr_ref_log_probs)

--- a/compose_rl/utils/utils.py
+++ b/compose_rl/utils/utils.py
@@ -83,6 +83,7 @@ def approx_kl(
     Args:
         log_p (torch.Tensor): log probabilities for the distribution p.
         log_q (torch.Tensor): log probabilities for the distribution q.
+        kl_clip_range (float): The clip range for diff of logprobs.
 
     Returns:
         kl_dict (dict[str, torch.Tensor]): a dictionary of the different KL divergence estimators.

--- a/compose_rl/utils/utils.py
+++ b/compose_rl/utils/utils.py
@@ -87,8 +87,13 @@ def approx_kl(log_p: torch.Tensor,
     ratio = (log_p - log_q).clamp(min=-40.0, max=40.0)
 
     approx_kl_k1 = -ratio
+    # The k2_loss is approximately equivalent to the one-step KL divergence penalty with the k1 estimator
+    # used in https://arxiv.org/pdf/2310.10505.
     approx_kl_k2 = 0.5 * (ratio**2)
+    # The k3 estimator is the non negative kl approximation in http://joschu.net/blog/kl-approx.html
     approx_kl_k3 = torch.expm1(ratio) - ratio
+    # This is taken from https://hongyuzang.notion.site/The-critical-implementation-detail-of-KL-loss-in-GRPO-1ae3fe2c1ff9809a9307c5402e190373
+    # This is specifically for off-policy learning and can be useful for async training.
     approx_kl_k3_offpolicy = 1.0 - torch.exp(ratio)
 
     kl_dict = {

--- a/yamls/local_ppo.yaml
+++ b/yamls/local_ppo.yaml
@@ -43,7 +43,6 @@ variables:
   # RL parameters
   gamma: 1.0
   lambda_gae: 0.95
-  kl_estimator: k3
 
   device_generate_batch_size: 32
 
@@ -84,7 +83,8 @@ model:
 
     joint_actor_critic: true
     compute_kl_loss: true
-    kl_estimator: k3
+    kl_estimator: k1
+    kl_clip_range: 40.0
 
 # load_path: # TODO: fill in load path if applicable
 # load_weights_only: true

--- a/yamls/local_ppo.yaml
+++ b/yamls/local_ppo.yaml
@@ -43,7 +43,7 @@ variables:
   # RL parameters
   gamma: 1.0
   lambda_gae: 0.95
-  kl_estimator: k1
+  kl_estimator: k3
 
   device_generate_batch_size: 32
 
@@ -84,6 +84,7 @@ model:
 
     joint_actor_critic: true
     compute_kl_loss: true
+    kl_estimator: k3
 
 # load_path: # TODO: fill in load path if applicable
 # load_weights_only: true


### PR DESCRIPTION
- We need all kl estimators for the loss as well, currently supported in rewards only
- This will help ensure that we use the same functions always and then just call them as necessary in loss or rewards

Run name: `test-kl-pr-new-Ya9Gvo`