### PR TITLE
Fix weight propagation

### DIFF
--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -406,6 +406,11 @@ def broadcast_to_vllm(
 
     for module_name, module in model.named_modules():
         if isinstance(module, FSDP):
+            # This is the root module for actor critic models. This is needed otherwise FSDP 
+            # will materialize parameters of size 0 
+            if module_name == 'model' and loss_type == 'ppo':
+                continue
+
             # Only update if we haven't updated this module before
             if module not in seen_fsdp_modules:
                 seen_fsdp_modules.add(module)

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -407,9 +407,9 @@ def broadcast_to_vllm(
     for module_name, module in model.named_modules():
         if isinstance(module, FSDP):
             # This should be the root module, and it's only initialized after we call forwards
-            if module_name == 'model':
+            # if module_name == 'model':
                 # print ("this should be the root module skipping", module)
-                continue
+                # continue
 
             # Only update if we haven't updated this module before
             if module not in seen_fsdp_modules:
@@ -448,8 +448,8 @@ def broadcast_to_vllm(
                                 start_update_time = time.time()
                                 seen_updated_parsed_names.add(parsed_name)
 
-                                print ("updating parsed name: ", parsed_name)
-                                print ("updating full name: ", full_name)
+                                print("updating parsed name: ", parsed_name)
+                                print("updating full name: ", full_name)
 
                                 count += 1
                                 shape = param.shape

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -347,6 +347,7 @@ def should_update_torch_module(
 
     Args:
         parsed_module_name (str): The parsed name of the module
+        full_param_name (str): The full name of the parameter
         module (nn.Module): The torch module to check
         loss_type (str): The loss type which decides whether to use critic-free or not. Defaults to "ppo".
         valid_non_leaf_module_names (list[str]): List of valid non-leaf module names

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -407,9 +407,9 @@ def broadcast_to_vllm(
     for module_name, module in model.named_modules():
         if isinstance(module, FSDP):
             # This should be the root module, and it's only initialized after we call forwards
-            if module_name == 'model':
-            # print ("this should be the root module skipping", module)
-                continue
+            # if module_name == 'model':
+                # print ("this should be the root module skipping", module)
+                # continue
 
             # Only update if we haven't updated this module before
             if module not in seen_fsdp_modules:
@@ -437,7 +437,11 @@ def broadcast_to_vllm(
                             if is_fsdp_leaf(module):
                                 update = True
                             elif parsed_name in valid_non_leaf_module_names:
-                                if (loss_type == 'ppo' and 'lm_backbone' in full_name or loss_type == 'grpo'):
+                                if (
+                                    loss_type == 'ppo' and
+                                    'lm_backbone' in full_name or
+                                    loss_type == 'grpo'
+                                ):
                                     update = True
 
                             # We've already updated this module before,

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -448,6 +448,9 @@ def broadcast_to_vllm(
                                 start_update_time = time.time()
                                 seen_updated_parsed_names.add(parsed_name)
 
+                                print ("updating parsed name: ", parsed_name)
+                                print ("updating full name: ", full_name)
+
                                 count += 1
                                 shape = param.shape
                                 refs = [

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -407,9 +407,9 @@ def broadcast_to_vllm(
     for module_name, module in model.named_modules():
         if isinstance(module, FSDP):
             # This should be the root module, and it's only initialized after we call forwards
-            # if module_name == 'model':
-                # print ("this should be the root module skipping", module)
-                # continue
+            if module_name == 'model':
+            # print ("this should be the root module skipping", module)
+                continue
 
             # Only update if we haven't updated this module before
             if module not in seen_fsdp_modules:
@@ -436,8 +436,9 @@ def broadcast_to_vllm(
                             # If we are at a leaf of a FSDP module we should always update it
                             if is_fsdp_leaf(module):
                                 update = True
-                            elif parsed_name in valid_non_leaf_module_names and 'lm_backbone' in full_name:
-                                update = True
+                            elif parsed_name in valid_non_leaf_module_names:
+                                if (loss_type == 'ppo' and 'lm_backbone' in full_name or loss_type == 'grpo'):
+                                    update = True
 
                             # We've already updated this module before,
                             if parsed_name in seen_updated_parsed_names:
@@ -448,8 +449,8 @@ def broadcast_to_vllm(
                                 start_update_time = time.time()
                                 seen_updated_parsed_names.add(parsed_name)
 
-                                print("updating parsed name: ", parsed_name)
-                                print("updating full name: ", full_name)
+                                print('updating parsed name: ', parsed_name)
+                                print('updating full name: ', full_name)
 
                                 count += 1
                                 shape = param.shape

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -406,11 +406,6 @@ def broadcast_to_vllm(
 
     for module_name, module in model.named_modules():
         if isinstance(module, FSDP):
-            # This should be the root module, and it's only initialized after we call forwards
-            # if module_name == 'model':
-                # print ("this should be the root module skipping", module)
-                # continue
-
             # Only update if we haven't updated this module before
             if module not in seen_fsdp_modules:
                 seen_fsdp_modules.add(module)
@@ -473,6 +468,10 @@ def broadcast_to_vllm(
                                     group=model_update_group,
                                 )
                                 update_time += time.time() - start_update_time
+    
+    assert num_params == count, (
+        f'Number of parameters updated {count} does not match the number of parameters {num_params}' + 
+        f'This means that some parameters were not updated.')
 
     log.info(f'for loop took: {time.time() - start_time}')
     start_time = time.time()

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -497,6 +497,7 @@ def broadcast_to_vllm(
                                 )
                                 update_time += time.time() - start_update_time
 
+    # Issue (#67): Note this code will likely need to be updated for PEFT for efficiency reasons.
     if dist.get_global_rank() == 0:
         # Check if the number of parameters updated is equal to the number of parameters
         # This can only be done on global rank 0, since it is the one that is updating the parameters.

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -468,10 +468,14 @@ def broadcast_to_vllm(
                                     group=model_update_group,
                                 )
                                 update_time += time.time() - start_update_time
-    
-    assert num_params == count, (
-        f'Number of parameters updated {count} does not match the number of parameters {num_params}' + 
-        f'This means that some parameters were not updated.')
+
+    if dist.get_global_rank() == 0:
+        # Check if the number of parameters updated is equal to the number of parameters
+        # This can only be done on global rank 0, since it is the one that is updating the parameters.
+        assert num_params == count, (
+            f'Number of parameters updated {count} does not match the number of parameters {num_params}'
+            + f'This means that some parameters were not updated.'
+        )
 
     log.info(f'for loop took: {time.time() - start_time}')
     start_time = time.time()

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -436,9 +436,8 @@ def broadcast_to_vllm(
 
     for module_name, module in model.named_modules():
         if isinstance(module, FSDP):
-            # This is the root module for the joint actor critic models. This is needed otherwise FSDP
-            # will materialize parameters of size 0. So just for the joint actor critic
-            # models we have to actually skip this module.
+            # This is needed otherwise FSDP will materialize parameters of size 0.
+            # So just for the joint actor critic models we have to actually skip this module.
             if module_name == 'model' and loss_type == 'ppo':
                 continue
 


### PR DESCRIPTION
How we implemented GRPO and PPO make slightly different necessary choices on module naming. This PR ensures that for each of these choices we:

1. Per algorithm `grpo`/ `ppo` we correctly send all of the weights. 
2. We add an assert in the function to ensure that every update updates the correct number of parameters.

GRPO run: debug-llama8b-weight-fix-QquYCx (done w/ llama 8b)
PPO run: check-actor-critic-parameters-p1Ujjt (done w/ qwen 7b)