### PR TITLE
Microbatching fixes

### DIFF
--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -500,6 +500,8 @@ class PPOCallback(CallbackWithConfig):
 
         self.precision = state.precision
         self.device_train_microbatch_size: int = state.device_train_microbatch_size  # type: ignore
+        if self.device_train_microbatch_size == 'auto':
+            raise ValueError('auto microbatching is not supported for PPO')
 
         self.iter_batch_size = self.num_batches_per_update * self.device_train_batch_size
 

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -500,7 +500,7 @@ class PPOCallback(CallbackWithConfig):
 
         self.precision = state.precision
         self.device_train_microbatch_size: int = state.device_train_microbatch_size  # type: ignore
-        if self.device_train_microbatch_size == 'auto':
+        if self.device_train_microbatch_size == 'auto':  # type: ignore
             raise ValueError('auto microbatching is not supported for PPO')
 
         self.iter_batch_size = self.num_batches_per_update * self.device_train_batch_size

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -22,6 +22,7 @@ from composer.core import (
     ensure_time,
     get_precision_context,
 )
+from composer.core.data_spec import _default_split_batch
 from composer.loggers import Logger, MLFlowLogger, WandBLogger
 from composer.trainer.trainer import _get_initial_device_train_microbatch_size
 from composer.utils import dist, ensure_tuple
@@ -217,15 +218,14 @@ def env_reward(
             'action_mask': action_mask,
             'actions': actions,
         }
+
+        microbatch_splits = _default_split_batch(
+            batch=input_model_kwargs,
+            microbatch_size=device_train_microbatch_size,
+        )
         # Compute the device_train_microbatch_log_probs inside the for loop to reduce the softmax overhead
-        for i in range(batch_size // device_train_microbatch_size):
-            curr_kwargs = {
-                key:
-                    value[i * device_train_microbatch_size:(i + 1) *
-                          device_train_microbatch_size]
-                    if isinstance(value, torch.Tensor) else value
-                for key, value in input_model_kwargs.items()
-            }
+        for split in microbatch_splits:
+            curr_kwargs = split
 
             cur_output = actor_critic(curr_kwargs)
             cur_logits = cur_output['logits']

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -216,7 +216,6 @@ class ComposerHFPolicyModel(ComposerHFPolicy):
             kl_estimator=self.config.kl_estimator,
             kl_clip_range=self.config.kl_clip_range,
         )
-        print(return_dict)
 
         self.policy_kl.append(kl_loss)
 

--- a/compose_rl/ppo/model.py
+++ b/compose_rl/ppo/model.py
@@ -216,6 +216,7 @@ class ComposerHFPolicyModel(ComposerHFPolicy):
             kl_estimator=self.config.kl_estimator,
             kl_clip_range=self.config.kl_clip_range,
         )
+        print(return_dict)
 
         self.policy_kl.append(kl_loss)
 

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -224,6 +224,8 @@ def online_rl_loss(
         if adv_masked_var.dim() > 0:
             adv_masked_var = adv_masked_var[0]
 
+        print("*"*30, adv_masked_mean, adv_masked_var)
+
         # Normalizing advantages over each minibatch
         advantages = utils.masked_normalize(
             batch['advantages'],

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -292,6 +292,8 @@ def online_rl_loss(
 
     if length_normalize_policy_loss:
         policy_loss = utils.masked_mean(policy_loss, batch['action_mask'], dim=-1).mean()
+        print("old*"*30, utils.masked_mean(policy_loss, batch['action_mask']))
+        print("new*"*30, policy_loss)
     else:
         policy_loss = utils.masked_sum(policy_loss, batch['action_mask'])
 

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -407,11 +407,12 @@ def online_rl_loss(
         return_dict[key] = value.detach().cpu()
 
     return_dict['total'] = policy_loss
+    print("1*"*30, return_dict['total'])
     if loss_type == 'ppo':
         # Add value loss to total loss
         return_dict['total'
                    ] += value_loss_weight * value_loss  # pyright: ignore
-
+    print("2*"*30, return_dict['total'])
     # If we want to directly minimize the KL Divergence, we can do so here
     # and it will not include the KL in the reward.
     if add_direct_kl_loss:
@@ -419,9 +420,9 @@ def online_rl_loss(
         return_dict['loss/online_ift_kl'] = (
             batch['ift_kl_scalar'][0] * online_ift_kl
         )
-
+    print("3*"*30, return_dict['total'])
     if 'lbl' in outputs and outputs['lbl'] is not None:
         return_dict['loss/lbl'] = outputs['lbl']
         return_dict['total'] += outputs['lbl']
-
+    print("4*"*30, return_dict['total'])
     return return_dict, policy_kl.detach().cpu()

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -191,7 +191,8 @@ def online_rl_loss(
 
         returns = advantages + values
         returns_mean = utils.sample_wise_masked_mean(
-            returns, batch['action_mask']
+            returns,
+            batch['action_mask'],
         )
         returns_var = utils.masked_var(returns, batch['action_mask'])
 
@@ -291,7 +292,8 @@ def online_rl_loss(
 
     if length_normalize_policy_loss:
         policy_loss = utils.sample_wise_masked_mean(
-            policy_loss, batch['action_mask']
+            policy_loss,
+            batch['action_mask'],
         )
     else:
         policy_loss = utils.masked_sum(policy_loss, batch['action_mask'])

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -260,8 +260,8 @@ def online_rl_loss(
             online_ift_kl_dict[kl_estimator], # pyright: ignore
             batch['action_mask'],
         )
-        print("+"*30, policy_kl_dict[kl_estimator])
-        print("-"*30, online_ift_kl_dict[kl_estimator])
+        print("+"*30, policy_kl_dict[kl_estimator], policy_kl_dict[kl_estimator].sum())
+        print("-"*30, online_ift_kl_dict[kl_estimator], online_ift_kl_dict[kl_estimator].sum())
     else:
         policy_kl = utils.masked_sum(
             policy_kl_dict[kl_estimator], # pyright: ignore

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -271,6 +271,7 @@ def online_rl_loss(
         )
 
     ratio = torch.exp(online_log_probs - old_log_probs)
+    print("*"*30, advantages, ratio)
     policy_loss_1 = -advantages * ratio
 
     # Use the same clip ratio for both sides if clip high ratio is not provided

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -291,7 +291,7 @@ def online_rl_loss(
     )
 
     if length_normalize_policy_loss:
-        policy_loss = utils.masked_mean(policy_loss, batch['action_mask'])
+        policy_loss = utils.masked_mean(policy_loss, batch['action_mask'], dim=-1).mean()
     else:
         policy_loss = utils.masked_sum(policy_loss, batch['action_mask'])
 

--- a/compose_rl/ppo/modeling_utils.py
+++ b/compose_rl/ppo/modeling_utils.py
@@ -260,6 +260,8 @@ def online_rl_loss(
             online_ift_kl_dict[kl_estimator], # pyright: ignore
             batch['action_mask'],
         )
+        print("+"*30, policy_kl_dict[kl_estimator])
+        print("-"*30, online_ift_kl_dict[kl_estimator])
     else:
         policy_kl = utils.masked_sum(
             policy_kl_dict[kl_estimator], # pyright: ignore

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -507,7 +507,6 @@ class RewardManager:
             kl_estimator (str): Which kl estimator to use. Options are 'k1', 'k2', 'k3', 'k3_offpolicy'.
             kl_clip_range (float): The clip range for the KL divergence.
         """
-        batch_size = batch['input_ids'].size(0)
         kl = []
         ref_model_log_probs = []
 

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -13,6 +13,7 @@ import spacy
 import torch
 from composer import Trainer
 from composer.core import Precision
+from composer.core.data_spec import _default_split_batch
 from llmfoundry.utils import build_composer_model
 # pyright does not recognize process_init_device though it is a declared export
 from llmfoundry.utils.config_utils import process_init_device  # type: ignore
@@ -509,14 +510,13 @@ class RewardManager:
         batch_size = batch['input_ids'].size(0)
         kl = []
         ref_model_log_probs = []
-        for i in range(batch_size // device_train_microbatch_size):
-            curr_batch = {
-                key:
-                    value[i * device_train_microbatch_size:(i + 1) *
-                          device_train_microbatch_size]
-                    if isinstance(value, torch.Tensor) else value
-                for key, value in batch.items()
-            }
+
+        microbatch_splits = _default_split_batch(
+            batch=batch,
+            microbatch_size=device_train_microbatch_size,
+        )
+        for split in microbatch_splits:
+            curr_batch = split
             curr_ref_output = self.reference_model(curr_batch)
             curr_ref_log_probs = get_log_probs(
                 logits=curr_ref_output.logits,

--- a/compose_rl/utils/__init__.py
+++ b/compose_rl/utils/__init__.py
@@ -4,6 +4,7 @@
 from compose_rl.utils.utils import (
     add_right_padding,
     approx_kl,
+    batch_preserving_masked_mean,
     batch_process_fine_granularities,
     clear_mb_load_balancing_loss,
     compute_advantages,
@@ -83,4 +84,5 @@ __all__ = [
     'init_process_group',
     'broadcast_to_vllm',
     'flatten',
+    'batch_preserving_masked_mean',
 ]

--- a/compose_rl/utils/__init__.py
+++ b/compose_rl/utils/__init__.py
@@ -4,7 +4,6 @@
 from compose_rl.utils.utils import (
     add_right_padding,
     approx_kl,
-    batch_preserving_masked_mean,
     batch_process_fine_granularities,
     clear_mb_load_balancing_loss,
     compute_advantages,
@@ -34,6 +33,7 @@ from compose_rl.utils.utils import (
     process_fine_granularities,
     remove_left_padding,
     rescale,
+    sample_wise_masked_mean,
     scatter_gather_rewards,
     split_text_to_sentences,
     split_text_to_subsentences,
@@ -84,5 +84,5 @@ __all__ = [
     'init_process_group',
     'broadcast_to_vllm',
     'flatten',
-    'batch_preserving_masked_mean',
+    'sample_wise_masked_mean',
 ]

--- a/compose_rl/utils/utils.py
+++ b/compose_rl/utils/utils.py
@@ -251,6 +251,12 @@ def masked_sum(
         return (values * mask).sum(dim=dim)
     return (values * mask).sum()
 
+def batch_preserving_masked_mean(
+    values: torch.Tensor,
+    mask: torch.Tensor,
+):
+    per_row = (values * mask).sum(dim=-1) / mask.sum(dim=-1)
+    return per_row.mean()
 
 def masked_mean(
     values: torch.Tensor,

--- a/compose_rl/utils/utils.py
+++ b/compose_rl/utils/utils.py
@@ -251,12 +251,30 @@ def masked_sum(
         return (values * mask).sum(dim=dim)
     return (values * mask).sum()
 
-def batch_preserving_masked_mean(
+
+def sample_wise_masked_mean(
     values: torch.Tensor,
     mask: torch.Tensor,
 ):
+    """Compute the mean of masked values, averaged across samples.
+
+    This function first computes the masked mean for each sample (row) independently,
+    then takes the average across all samples. This is different from a global masked
+    mean as it gives equal weight to each sample regardless of how many valid (unmasked)
+    elements each sample contains.
+
+    Args:
+        values (torch.Tensor): Input tensor of shape (..., sequence_length) containing
+            the values to compute the mean over.
+        mask (torch.Tensor): Binary mask tensor of the same shape as values, where
+            1 indicates valid values and 0 indicates values to ignore.
+
+    Returns:
+        torch.Tensor: A scalar tensor containing the sample-wise masked mean.
+    """
     per_row = (values * mask).sum(dim=-1) / mask.sum(dim=-1)
     return per_row.mean()
+
 
 def masked_mean(
     values: torch.Tensor,


### PR DESCRIPTION
Multiple fixes:
(1) Hard error on dtms auto. We can support this later, but right now it crashes in a less obvious way.
(2) Adjust microbatch splitting logic so that microbatch sizes that do not evenly divide global batch size work.
(3) Adjust all the masked means in loss computation to first mean per sample and then mean across samples. This preserves the math for varying batch size. Let me know if you think this is wrong.

Adds a unit test for the new helper function added. We should add more comprehensive testing for the loss function, but deferring that to a separate PR.

Note: KL still differs slightly because logits themselves differ slightly between batch sizes. Accepting this for now.

Manual tests:
Loss is now the same with different mb sizes (1-4), and is the same as main branch with mb size 1. Previously the loss was quite different when using different mb sizes.

PPO:
<img width="654" alt="Screenshot 2025-05-22 at 11 13 12 AM" src="https://github.com/user-attachments/assets/94452666-d3bd-4918-832d-01cc309f79fa" />

GRPO:
<img width="629" alt="Screenshot 2025-05-22 at 11 12 55 AM" src="https://github.com/user-attachments/assets/be3eb2a7-de2d-4ea7-9aee-15c820568464" />
