### PR TITLE
Adding a Math format verifier

### DIFF
--- a/compose_rl/reward_learning/__init__.py
+++ b/compose_rl/reward_learning/__init__.py
@@ -8,9 +8,10 @@ from compose_rl.reward_learning.base_reward import (
 )
 from compose_rl.reward_learning.functional import (
     BadGenerationEndReward,
-    GSM8KAnswerVeriferReward,
     GSM8KFormatVeriferReward,
+    GSM8KVeriferReward,
     IncreasingNumbersReward,
+    MATHFormatVerifierReward,
     MATHVerifierReward,
     OutputLengthReward,
     ShortResponseReward,
@@ -40,9 +41,10 @@ rewards.register('inference_reward_model', func=InferenceRewardModel)
 rewards.register('mpt_pairwise', func=ComposerMPTPairwiseRewardModel)
 rewards.register('hf_pairwise', func=ComposerHFPairwiseRewardModel)
 rewards.register('bad_generation_end', func=BadGenerationEndReward)
-rewards.register('gsm8k_answer_verifier', func=GSM8KAnswerVeriferReward)
+rewards.register('gsm8k_verifier', func=GSM8KVeriferReward)
 rewards.register('gsm8k_format_verifier', func=GSM8KFormatVeriferReward)
 rewards.register('math_verifier', func=MATHVerifierReward)
+rewards.register('math_format_verifier', func=MATHFormatVerifierReward)
 
 __all__ = [
     'BaseReward',
@@ -57,6 +59,7 @@ __all__ = [
     'OutputLengthReward',
     'ShortResponseReward',
     'GSM8KFormatVeriferReward',
-    'GSM8KAnswerVeriferReward',
+    'GSM8KVeriferReward',
     'MATHVerifierReward',
+    'MATHFormatVerifierReward',
 ]

--- a/compose_rl/reward_learning/functional.py
+++ b/compose_rl/reward_learning/functional.py
@@ -357,7 +357,7 @@ class BaseVerifierReward(Reward):
         )
 
 
-class GSM8KAnswerVeriferReward(BaseVerifierReward):
+class GSM8KVeriferReward(BaseVerifierReward):
 
     def __init__(self, tokenizer: Tokenizer, reward: float = 1.0):
         super().__init__(tokenizer=tokenizer, reward=reward)

--- a/compose_rl/reward_learning/functional.py
+++ b/compose_rl/reward_learning/functional.py
@@ -363,14 +363,7 @@ class GSM8KAnswerVeriferReward(BaseVerifierReward):
         super().__init__(tokenizer=tokenizer, reward=reward)
 
     def extract_solution(self, text: str) -> str:
-        """Extract numerical solution from GSM8K-style responses.
-
-        Args:
-            text (str): The generated text.
-
-        Returns:
-            str: The extracted numerical answer.
-        """
+        """Extract numerical solution from GSM8K-style responses."""
         numbers = re.findall(r'-?[\d,]*\.?\d+', text)
         final_answer = ''
         if len(numbers) > 0:
@@ -382,15 +375,7 @@ class GSM8KAnswerVeriferReward(BaseVerifierReward):
         return final_answer
 
     def score_generations(self, answer: str, label: str) -> float:
-        """Score based on exact match.
-
-        Args:
-            answer (str): The extracted answer.
-            label (str): The verified answer.
-
-        Returns:
-            float: self.reward for match, 0.0 otherwise.
-        """
+        """Score based on exact match."""
         return self.reward if answer == label else 0.0
 
 
@@ -404,7 +389,7 @@ class GSM8KFormatVeriferReward(BaseVerifierReward):
         return False
 
     def score_generations(self, answer: str, label: str) -> float:
-        """Check if the answer follows the expected format with '####' marker.
+        """Check if the answer follows the format with '####' marker.
 
         Note: The label parameter is not used in this implementation but is required
         by the interface.
@@ -419,14 +404,7 @@ class MATHVerifierReward(BaseVerifierReward):
         super().__init__(tokenizer=tokenizer, reward=reward)
 
     def extract_solution(self, text: str) -> str:
-        """Extract numerical solution from GSM8K-style responses.
-
-        Args:
-            text (str): The generated text.
-
-        Returns:
-            str: The extracted numerical answer.
-        """
+        """Extract numerical solution from MATH-style responses."""
         last_boxed_string = last_boxed_only_string(text)
         if not last_boxed_string:
             # No boxed string found, so we can't evaluate
@@ -436,15 +414,26 @@ class MATHVerifierReward(BaseVerifierReward):
         return normalize_final_answer(unnormalized_answer)
 
     def score_generations(self, answer: str, label: str) -> float:
-        """Score based on exact match.
-
-        Args:
-            answer (str): The extracted answer.
-            label (str): The verified answer.
-
-        Returns:
-            float: self.reward for match, 0.0 otherwise.
-        """
+        """Score based on exact match or sympy equivalence checks."""
         if answer.strip() == label.strip() or is_equiv(answer, label):
             return self.reward
         return 0.0
+
+
+class MATHFormatVerifierReward(BaseVerifierReward):
+
+    def __init__(self, tokenizer: Tokenizer, reward: float = 1.0):
+        super().__init__(tokenizer=tokenizer, reward=reward)
+
+    def needs_extraction(self) -> bool:
+        """Indicate that this verifier doesn't need extraction."""
+        return False
+
+    def score_generations(self, answer: str, label: str) -> float:
+        r"""Check if the answer follows the format with '\\boxed{{}}' marker.
+
+        Note: The label parameter is not used in this implementation but is required
+        by the interface.
+        """
+        last_boxed_string = last_boxed_only_string(answer)
+        return 0.0 if not last_boxed_string else self.reward

--- a/tests/functional_rewards/test_gsm8k_verifier_reward.py
+++ b/tests/functional_rewards/test_gsm8k_verifier_reward.py
@@ -1,0 +1,73 @@
+# Copyright 2024 MosaicML ComposeRL authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GSM8KVeriferReward class."""
+
+from typing import Any
+
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+from compose_rl.reward_learning import GSM8KVeriferReward
+
+
+@pytest.fixture
+def reward() -> GSM8KVeriferReward:
+    tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')
+    return GSM8KVeriferReward(reward=1.0, tokenizer=tokenizer)
+
+
+def test_call_base_verifer_invalid_input(
+    reward: GSM8KVeriferReward,
+) -> None:
+    invalid_batch: dict[str, torch.Tensor] = {
+        'zero_rewards': torch.zeros((2, 6)),
+        'generated_lens': torch.tensor([6, 6]),
+    }
+    with pytest.raises(AssertionError):
+        reward(invalid_batch)
+
+
+@pytest.mark.parametrize(
+    'batch, expected_rewards',
+    [
+        (
+            {
+                'zero_rewards': torch.zeros((3, 5)),
+                'raw_untokenized_texts': [
+                    ('', 'Answer is ####24'),
+                    ('', 'This is a very long string answer'),
+                    (
+                        '',
+                        'There are 32 initial numbers, adding 64 new elements gives 32+64 = 96. Answer is \\boxed{96}',
+                    ),
+                ],
+                'verified_answers': ['24', '89', '96'],
+                'generated_lens': torch.tensor([5, 5, 3]),
+            },
+            [(0, 4, 1.0), (1, 4, 0.0), (2, 2, 1.0)],
+        ),
+        (
+            {
+                'zero_rewards': torch.zeros((2, 6)),
+                'raw_untokenized_texts': [
+                    ('', '####1'),
+                    ('', '##2'),
+                ],
+                'verified_answers': ['1', '4'],
+                'generated_lens': torch.tensor([6, 6]),
+            },
+            [(0, 5, 1.0), (1, 5, 0.0)],
+        ),
+    ],
+)
+def test_gms8k_answer_verifier(
+    reward: GSM8KVeriferReward,
+    batch: dict[str, Any],
+    expected_rewards: list[tuple[int, int, float]],
+) -> None:
+    result = reward(batch)
+    assert result.shape == batch['zero_rewards'].shape
+    for idx, pos, expected in expected_rewards:
+        assert pytest.approx(result[idx, pos].item(), abs=1e-6) == expected

--- a/tests/functional_rewards/test_math_format_verifier_reward.py
+++ b/tests/functional_rewards/test_math_format_verifier_reward.py
@@ -47,7 +47,7 @@ def test_call_base_verifer_invalid_input(reward: MATHFormatVerifierReward) -> No
                 'verified_answers': ['24', 'y^4-2y^3+7y^2+y-4', '2'],
                 'generated_lens': torch.tensor([5, 5, 3]),
             },
-            [(0, 4, 10.0), (1, 4, 0.0), (2, 2, 10.0)],
+            [(0, 4, 10.0), (1, 4, 10.0), (2, 2, 0.0)],
         ),
         (
             {

--- a/tests/functional_rewards/test_math_format_verifier_reward.py
+++ b/tests/functional_rewards/test_math_format_verifier_reward.py
@@ -18,7 +18,9 @@ def reward() -> MATHFormatVerifierReward:
     return MATHFormatVerifierReward(reward=10.0, tokenizer=tokenizer)
 
 
-def test_call_base_verifer_invalid_input(reward: MATHFormatVerifierReward) -> None:
+def test_call_base_verifer_invalid_input(
+    reward: MATHFormatVerifierReward,
+) -> None:
     invalid_batch: dict[str, torch.Tensor] = {
         'zero_rewards': torch.zeros((2, 6)),
         'generated_lens': torch.tensor([6, 6]),


### PR DESCRIPTION
- Format rewards are showing to play an important role in providing extra learning singals.
- This adds one for the MATH set of evals (both math_500, but then all competition evals)