### PR TITLE
Set default value as this is only used for local debugging

### DIFF
--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -382,7 +382,8 @@ class PPOCallback(CallbackWithConfig):
 
         # Per-device generate size.
         self.device_generate_batch_size: int = var_config.get(
-            'device_generate_batch_size', 1
+            'device_generate_batch_size',
+            1,
         )
         self.device_train_batch_size: int = train_config.get(
             'device_train_batch_size',


### PR DESCRIPTION
- Set `device_generate_batch_size` to have a default value of 1 