### PR TITLE
Fix reward timeouts

### DIFF
--- a/compose_rl/interfaces/base_reward.py
+++ b/compose_rl/interfaces/base_reward.py
@@ -29,6 +29,7 @@ class BaseReward(ABC):
 
     # Whether the class blocks (True) or can be run async (False)
     BLOCKING: bool = True
+    BLOCKING_TIMEOUT: float = 10.0  # seconds
 
     def __init__(
         self,

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -201,8 +201,6 @@ def env_reward(
                                             max_gen_len))
             untokenized_prompt_and_responses.append((prompt, generated_text),)
 
-        log.debug('ckpt4')
-
         # Making logits [batch_size, generated_len, vocab_size]
         # We need to recompute the logits here. Otherwise there are numerical differences
         # We also need to do it on the size of `device_train_microbatch_size` otherwise

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -762,7 +762,7 @@ class PPOCallback(CallbackWithConfig):
         # Add the prepared sequences to the batch again
         batch['sequences'] = sequences
 
-        log.debug("Beginning reward computation for the rollout.")
+        log.debug('Beginning reward computation for the rollout.')
         start_reward_time = time.time()
 
         env_outputs, prompts_and_gens, ref_outputs, all_rewards_dict = env_reward(
@@ -780,7 +780,9 @@ class PPOCallback(CallbackWithConfig):
 
         end_reward_time = time.time()
         total_reward_time = end_reward_time - start_reward_time
-        log.debug(f"Finished reward computation for the rollout in {total_reward_time:.4f} seconds.")
+        log.debug(
+            f'Finished reward computation for the rollout in {total_reward_time:.4f} seconds.',
+        )
 
         self.prompts_and_gens.extend(prompts_and_gens)
 
@@ -955,7 +957,7 @@ class PPOCallback(CallbackWithConfig):
                 f'Invalid loss type: {self.actor_critic.loss_type}. ' +
                 'Valid options are: ppo, grpo.',
             )
-        
+
         log.debug('advantages computed')
 
         log.debug('computing ift kl')
@@ -994,7 +996,7 @@ class PPOCallback(CallbackWithConfig):
                 env_outs['rewards'].std().to('cpu'),
         })
         log.debug('iter_batch updated with ref outputs')
-        
+
         log.debug('moving iter_batch to cpu')
         # Moving minibatches to CPU to not take additional GPU memory
         for k, v in iter_batch.items():

--- a/compose_rl/ppo/callback.py
+++ b/compose_rl/ppo/callback.py
@@ -970,10 +970,15 @@ class PPOCallback(CallbackWithConfig):
         )
         log.debug('ift kl computed')
 
+        log.debug('moving ift kl to cpu')
         self.kl_ift.append(mean_ift.cpu())
+        log.debug('ift kl moved to cpu')
 
+        log.debug('updating iter_batch with env outputs')
         iter_batch.update(env_outs)
+        log.debug('iter_batch updated with env outputs')
 
+        log.debug('updating iter_batch with ref outputs')
         iter_batch.update({
             'max_gen_len':
                 torch.ones(self.iter_batch_size).to(torch.int32) *
@@ -988,6 +993,7 @@ class PPOCallback(CallbackWithConfig):
                 torch.ones(self.iter_batch_size) *
                 env_outs['rewards'].std().to('cpu'),
         })
+        log.debug('iter_batch updated with ref outputs')
         
         log.debug('moving iter_batch to cpu')
         # Moving minibatches to CPU to not take additional GPU memory

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -347,6 +347,7 @@ class RewardManager:
                 async, the associated value is an AsyncResult object that will return
                 the reward tensor from its `.get()` method.
         """
+        log.debug('inside reward manager call')
         device = right_padded_obses.device.type
 
         # Only process text for the existing granularity types of the rewards
@@ -383,6 +384,7 @@ class RewardManager:
             self.inference_rewards,
             self.local_reward_models,
         ):
+            log.debug(f'Computing reward for {reward_name}')
             curr_reward = self.all_rewards[reward_name]
             curr_batch = self._create_batch(
                 self.all_rewards[reward_name],
@@ -420,6 +422,8 @@ class RewardManager:
                 raise TypeError(
                     f'Unknown reward model type {type(curr_reward)}. Expected `Reward` or `RewardModel`.',
                 )
+            log.debug(f'Finished computing reward for {reward_name}')
+        log.debug('finished computing rewards for all reward models')
 
         batch['zero_rewards'] = self.make_zero_reward(action_log_probs)
         # Lastly, call the reference model
@@ -430,6 +434,7 @@ class RewardManager:
             kl_clip_range,
         )
 
+        log.debug('finished reward manager call')
         return ref_output, computed_rewards
 
     def _create_batch(

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -5,7 +5,7 @@
 
 import logging
 from itertools import chain
-from multiprocessing import get_context
+from multiprocessing import get_context, TimeoutError
 from multiprocessing.pool import AsyncResult, Pool
 from typing import Any, MutableMapping, Optional, Union
 
@@ -591,7 +591,14 @@ class RewardManager:
             log.debug(f'subreward type: {type(subreward)}')
             if isinstance(subreward, AsyncResult):
                 log.debug(f'Waiting for {name} reward to finish')
-                resolved_reward: torch.Tensor = subreward.get()
+                try:
+                    resolved_reward: torch.Tensor = subreward.get(timeout=self.all_rewards[name].BLOCKING_TIMEOUT)
+                except TimeoutError:
+                    log.error(
+                        f'Timeout while waiting for {name} reward to finish. ' +
+                        'This may indicate a problem with the reward. Using a default reward of 0.',
+                    )
+                    resolved_reward = self.make_zero_reward(action_mask)
                 log.debug(f'Finished waiting for {name} reward')
             else:
                 resolved_reward: torch.Tensor = subreward

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -598,7 +598,7 @@ class RewardManager:
                         f'Timeout while waiting for {name} reward to finish. ' +
                         'This may indicate a problem with the reward. Using a default reward of 0.',
                     )
-                    resolved_reward = self.make_zero_reward(action_mask)
+                    resolved_reward = self.make_zero_reward(action_mask).to(torch.float32)
                 log.debug(f'Finished waiting for {name} reward')
             else:
                 resolved_reward: torch.Tensor = subreward

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -578,6 +578,7 @@ class RewardManager:
                 aggregate reward for RL training, as well as the rewards from each
                 reward model.
         """
+        log.debug('inside reward manager resolve outputs')
         device = action_mask.device
 
         # Resolve any output elements that are being computed async,
@@ -586,8 +587,12 @@ class RewardManager:
         bad_end_generation_mask = None
         bad_end_generation_name = None
         for name, subreward in reward_output.items():
+            log.debug(f'Resolving reward for {name}')
+            log.debug(f'subreward type: {type(subreward)}')
             if isinstance(subreward, AsyncResult):
+                log.debug(f'Waiting for {name} reward to finish')
                 resolved_reward: torch.Tensor = subreward.get()
+                log.debug(f'Finished waiting for {name} reward')
             else:
                 resolved_reward: torch.Tensor = subreward
             resolved_reward_outputs[name] = resolved_reward.to(device=device)
@@ -602,6 +607,7 @@ class RewardManager:
                     device=device,
                 )
 
+        log.debug('finished resolving all rewards')
         ref_kl = ref_output[0].to(device=device)
         ref_log_probs = ref_output[1].to(device=device)
 
@@ -625,6 +631,8 @@ class RewardManager:
             out_name = name + '_reward' if 'reward' not in name else ''
             rews_dict_out[out_name] = subreward.detach() * action_mask
 
+        log.debug('rr1')
+
         # Masking out all rewards if the generation ends with a bad token
         # And strictly adding a penalty for bad generation ending.
         if bad_end_generation_mask is not None and bad_end_generation_name is not None:
@@ -644,7 +652,7 @@ class RewardManager:
         # Zero rewards at padded tokens
         rewards *= action_mask
         env_rewards *= action_mask
-
+        log.debug('rr2')
         outputs = {
             'rewards': rewards.detach(),
             'env_rewards': env_rewards.detach(),
@@ -653,4 +661,5 @@ class RewardManager:
         }
         outputs.update(rews_dict_out)
 
+        log.debug('finished reward manager resolve outputs')
         return outputs

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -347,7 +347,6 @@ class RewardManager:
                 async, the associated value is an AsyncResult object that will return
                 the reward tensor from its `.get()` method.
         """
-        log.debug('inside reward manager call')
         device = right_padded_obses.device.type
 
         # Only process text for the existing granularity types of the rewards
@@ -384,7 +383,6 @@ class RewardManager:
             self.inference_rewards,
             self.local_reward_models,
         ):
-            log.debug(f'Computing reward for {reward_name}')
             curr_reward = self.all_rewards[reward_name]
             curr_batch = self._create_batch(
                 self.all_rewards[reward_name],
@@ -422,8 +420,6 @@ class RewardManager:
                 raise TypeError(
                     f'Unknown reward model type {type(curr_reward)}. Expected `Reward` or `RewardModel`.',
                 )
-            log.debug(f'Finished computing reward for {reward_name}')
-        log.debug('finished computing rewards for all reward models')
 
         batch['zero_rewards'] = self.make_zero_reward(action_log_probs)
         # Lastly, call the reference model
@@ -434,7 +430,6 @@ class RewardManager:
             kl_clip_range,
         )
 
-        log.debug('finished reward manager call')
         return ref_output, computed_rewards
 
     def _create_batch(

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -5,7 +5,7 @@
 
 import logging
 from itertools import chain
-from multiprocessing import get_context, TimeoutError
+from multiprocessing import TimeoutError, get_context
 from multiprocessing.pool import AsyncResult, Pool
 from typing import Any, MutableMapping, Optional, Union
 
@@ -592,13 +592,17 @@ class RewardManager:
             if isinstance(subreward, AsyncResult):
                 log.debug(f'Waiting for {name} reward to finish')
                 try:
-                    resolved_reward: torch.Tensor = subreward.get(timeout=self.all_rewards[name].BLOCKING_TIMEOUT)
+                    resolved_reward: torch.Tensor = subreward.get(
+                        timeout=self.all_rewards[name].BLOCKING_TIMEOUT,
+                    )
                 except TimeoutError:
                     log.error(
                         f'Timeout while waiting for {name} reward to finish. ' +
                         'This may indicate a problem with the reward. Using a default reward of 0.',
                     )
-                    resolved_reward = self.make_zero_reward(action_mask).to(torch.float32)
+                    resolved_reward = self.make_zero_reward(action_mask).to(
+                        torch.float32,
+                    )
                 log.debug(f'Finished waiting for {name} reward')
             else:
                 resolved_reward: torch.Tensor = subreward

--- a/compose_rl/utils/utils.py
+++ b/compose_rl/utils/utils.py
@@ -365,7 +365,6 @@ def dist_compute_masked_mean_and_var(
     unbiased: Optional[bool] = True,
 ):
     """Computes the distributed masked mean and variance of a tensor."""
-    log.debug('inside dist mean and var')
     assert len(tensor.shape) == 2
 
     num_unmasked_elements = mask.sum()
@@ -374,9 +373,7 @@ def dist_compute_masked_mean_and_var(
     masked_tensor_sum = (tensor * mask).sum()
 
     dist.all_reduce(num_unmasked_elements)
-    dist.barrier()
     dist.all_reduce(masked_tensor_sum)
-    dist.barrier()
 
     global_tensor_mean = masked_tensor_sum / num_unmasked_elements
 
@@ -385,7 +382,6 @@ def dist_compute_masked_mean_and_var(
     centered_values = centered_values.sum()
 
     dist.all_reduce(centered_values)
-    dist.barrier()
     global_variance = centered_values / num_unmasked_elements
     if unbiased:
         bessel_correction = num_unmasked_elements / (num_unmasked_elements - 1)

--- a/compose_rl/utils/utils.py
+++ b/compose_rl/utils/utils.py
@@ -365,6 +365,7 @@ def dist_compute_masked_mean_and_var(
     unbiased: Optional[bool] = True,
 ):
     """Computes the distributed masked mean and variance of a tensor."""
+    log.debug('inside dist mean and var')
     assert len(tensor.shape) == 2
 
     num_unmasked_elements = mask.sum()
@@ -372,8 +373,14 @@ def dist_compute_masked_mean_and_var(
     # Get the masked tensor sum
     masked_tensor_sum = (tensor * mask).sum()
 
+    log.debug('ar1')
     dist.all_reduce(num_unmasked_elements)
+    log.debug('ar2')
+    dist.barrier()
+    log.debug('ar3')
     dist.all_reduce(masked_tensor_sum)
+    dist.barrier()
+    log.debug('ar4')
 
     global_tensor_mean = masked_tensor_sum / num_unmasked_elements
 
@@ -381,7 +388,11 @@ def dist_compute_masked_mean_and_var(
     centered_values *= mask
     centered_values = centered_values.sum()
 
+    log.debug('ar5')
     dist.all_reduce(centered_values)
+    log.debug('ar6')
+    dist.barrier()
+    log.debug('ar7')
     global_variance = centered_values / num_unmasked_elements
     if unbiased:
         bessel_correction = num_unmasked_elements / (num_unmasked_elements - 1)

--- a/compose_rl/utils/utils.py
+++ b/compose_rl/utils/utils.py
@@ -373,14 +373,10 @@ def dist_compute_masked_mean_and_var(
     # Get the masked tensor sum
     masked_tensor_sum = (tensor * mask).sum()
 
-    log.debug('ar1')
     dist.all_reduce(num_unmasked_elements)
-    log.debug('ar2')
     dist.barrier()
-    log.debug('ar3')
     dist.all_reduce(masked_tensor_sum)
     dist.barrier()
-    log.debug('ar4')
 
     global_tensor_mean = masked_tensor_sum / num_unmasked_elements
 
@@ -388,11 +384,8 @@ def dist_compute_masked_mean_and_var(
     centered_values *= mask
     centered_values = centered_values.sum()
 
-    log.debug('ar5')
     dist.all_reduce(centered_values)
-    log.debug('ar6')
     dist.barrier()
-    log.debug('ar7')
     global_variance = centered_values / num_unmasked_elements
     if unbiased:
         bessel_correction = num_unmasked_elements / (num_unmasked_elements - 1)

--- a/tests/test_reward_manager_timeout.py
+++ b/tests/test_reward_manager_timeout.py
@@ -15,40 +15,51 @@ ensure that:
 """
 
 import multiprocessing
+from multiprocessing.pool import AsyncResult
+from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from composer.core import Precision
+from omegaconf import DictConfig
 from transformers import PreTrainedTokenizerBase
 
-from compose_rl.ppo.reward_manager import RewardManager
+from compose_rl.ppo.reward_manager import RewardManager, RewardOutput
 from compose_rl.reward_learning import InferenceRewardModel
 
 
-class MockAsyncResult(multiprocessing.pool.AsyncResult):
+class MockAsyncResult(AsyncResult):
     """Mock AsyncResult that simulates timeout."""
-    
-    def __init__(self, should_timeout: bool = True, return_value: torch.Tensor = None):
+
+    def __init__(
+        self,
+        should_timeout: bool = True,
+        return_value: Optional[torch.Tensor] = None,
+    ):
         # Don't call super().__init__ to avoid complex initialization
         self.should_timeout = should_timeout
         self.return_value = return_value
-    
-    def get(self, timeout=None):
+
+    def get(self, timeout: Optional[float] = None) -> torch.Tensor:
         if self.should_timeout:
-            raise multiprocessing.TimeoutError("Mock timeout")
+            raise multiprocessing.TimeoutError('Mock timeout')
+        if self.return_value is None:
+            # Return a default tensor if none provided
+            return torch.zeros(2, 10)
         return self.return_value
 
 
 class MockRewardModel(InferenceRewardModel):
     """Mock reward model with timeout configuration."""
-    
+
     BLOCKING_TIMEOUT = 1.0  # 1 second timeout for testing
-    
-    def __init__(self):
+
+    def __init__(self) -> None:
         # Don't call super().__init__ to avoid complex initialization
         pass
-    
-    def __call__(self, batch):
+
+    def __call__(self, batch: Any) -> torch.Tensor:
         # Mock reward model computation
         batch_size = batch['zero_rewards'].shape[0]
         seq_len = batch['zero_rewards'].shape[1]
@@ -56,78 +67,86 @@ class MockRewardModel(InferenceRewardModel):
 
 
 @pytest.fixture
-def mock_reward_manager(tiny_gpt2_tokenizer: PreTrainedTokenizerBase):
+def mock_reward_manager(
+    tiny_gpt2_tokenizer: PreTrainedTokenizerBase,
+) -> RewardManager:
     """Create a minimal RewardManager for testing."""
-    config = {
+    config = DictConfig({
         'test_model': {
             'reward_type': 'inference_reward_model',
             'reward_coefficient': 1.0,
             'granularity': 'document',
-        }
-    }
-    
+        },
+    })
+
     ref_config = {
         'model_config': {
             'name': 'hf_causal_lm',
             'pretrained_model_name_or_path': 'gpt2',
             'pretrained': True,
-        }
+        },
     }
-    
+
     # Create RewardManager with minimal initialization
     with patch.object(RewardManager, 'initialize_composer_model') as mock_init:
         with patch('compose_rl.ppo.reward_manager.spacy.load') as mock_spacy:
             mock_ref_model = Mock()
             mock_init.return_value = mock_ref_model
-            
+
             # Mock spacy parser
             mock_parser = Mock()
             mock_spacy.return_value = mock_parser
-            
+
             # Patch the reward registry and build_reward
-            with patch('compose_rl.ppo.reward_manager.rewards_registry') as mock_registry:
-                with patch('compose_rl.ppo.reward_manager.build_reward') as mock_build:
+            with patch(
+                'compose_rl.ppo.reward_manager.rewards_registry',
+            ) as mock_registry:
+                with patch(
+                    'compose_rl.ppo.reward_manager.build_reward',
+                ) as mock_build:
                     mock_registry.get.return_value = InferenceRewardModel
                     mock_reward_model = MockRewardModel()
                     mock_build.return_value = mock_reward_model
-                    
+
                     reward_manager = RewardManager(
                         config=config,
                         ref_config=ref_config,
-                        tokenizer=tiny_gpt2_tokenizer,
+                        tokenizer=tiny_gpt2_tokenizer,  # type: ignore
                         max_seq_len=32,
                         fsdp_config=None,
-                        precision='fp32',
+                        precision=Precision.FP32,
                     )
-                    
+
                     # Manually set up the reward model
                     reward_manager.all_rewards['test_model'] = mock_reward_model
                     reward_manager.inference_rewards = ['test_model']
-                    
+
                     return reward_manager
 
 
-def test_async_timeout_creates_zero_reward(mock_reward_manager):
+def test_async_timeout_creates_zero_reward(
+    mock_reward_manager: RewardManager,
+) -> None:
     """Test that async timeout creates proper zero reward tensor."""
     batch_size, seq_len = 2, 10
-    
-    # Create test inputs  
+
+    # Create test inputs
     action_mask = torch.ones(batch_size, seq_len)
     ref_output = (
         torch.zeros(batch_size, seq_len),  # ref_kl
         torch.zeros(batch_size, seq_len),  # ref_log_probs
     )
-    
+
     # Create reward output with timeout AsyncResult
     timeout_async_result = MockAsyncResult(should_timeout=True)
-    reward_output = {
-        'test_model': timeout_async_result
+    reward_output: RewardOutput = {
+        'test_model': timeout_async_result,
     }
-    
+
     # Mock KL controller
     mock_kl_ctl = Mock()
     mock_kl_ctl.value = 0.1
-    
+
     # Test resolve_outputs with timeout
     with patch('compose_rl.ppo.reward_manager.log') as mock_log:
         outputs = mock_reward_manager.resolve_outputs(
@@ -136,50 +155,55 @@ def test_async_timeout_creates_zero_reward(mock_reward_manager):
             kl_ctl=mock_kl_ctl,
             action_mask=action_mask,
         )
-    
+
     # Verify error was logged
     mock_log.error.assert_called_once()
     error_msg = mock_log.error.call_args[0][0]
     assert 'Timeout while waiting for test_model reward to finish' in error_msg
     assert 'Using a default reward of 0' in error_msg
-    
+
     # Verify outputs have correct structure
     assert 'rewards' in outputs
     assert 'env_rewards' in outputs
     assert 'test_model_reward' in outputs  # reward name gets _reward suffix
-    
+
     # Verify the reward tensor has correct shape and is all zeros
     reward_tensor = outputs['test_model_reward']
     assert reward_tensor.shape == (batch_size, seq_len)
     assert torch.allclose(reward_tensor, torch.zeros_like(reward_tensor))
-    
+
     # Verify tensor properties match action_mask
     assert reward_tensor.device == action_mask.device
     assert reward_tensor.dtype == action_mask.dtype
 
 
-def test_async_success_works_normally(mock_reward_manager):
+def test_async_success_works_normally(
+    mock_reward_manager: RewardManager,
+) -> None:
     """Test that non-timeout case works normally."""
     batch_size, seq_len = 2, 10
-    
+
     # Create test inputs
     action_mask = torch.ones(batch_size, seq_len)
     ref_output = (
         torch.zeros(batch_size, seq_len),  # ref_kl
         torch.zeros(batch_size, seq_len),  # ref_log_probs
     )
-    
+
     # Create successful reward tensor
     expected_reward = torch.ones(batch_size, seq_len) * 0.5
-    success_async_result = MockAsyncResult(should_timeout=False, return_value=expected_reward)
-    reward_output = {
-        'test_model': success_async_result
+    success_async_result = MockAsyncResult(
+        should_timeout=False,
+        return_value=expected_reward,
+    )
+    reward_output: RewardOutput = {
+        'test_model': success_async_result,
     }
-    
+
     # Mock KL controller
     mock_kl_ctl = Mock()
     mock_kl_ctl.value = 0.1
-    
+
     # Test resolve_outputs without timeout
     outputs = mock_reward_manager.resolve_outputs(
         ref_output=ref_output,
@@ -187,39 +211,44 @@ def test_async_success_works_normally(mock_reward_manager):
         kl_ctl=mock_kl_ctl,
         action_mask=action_mask,
     )
-    
+
     # Verify the reward tensor matches expected values
     reward_tensor = outputs['test_model_reward']
     assert reward_tensor.shape == (batch_size, seq_len)
     assert torch.allclose(reward_tensor, expected_reward * action_mask)
 
 
-def test_mixed_timeout_and_success(mock_reward_manager):
-    """Test scenario with multiple rewards where some timeout and some succeed."""
+def test_mixed_timeout_and_success(mock_reward_manager: RewardManager) -> None:
+    """Test scenario with multiple rewards where some timeout and some succeed.
+
+    This test validates that the RewardManager can handle mixed scenarios where
+    some async rewards timeout while others succeed normally.
+    """
     batch_size, seq_len = 2, 10
-    
+
     # Add another reward model to the manager
     mock_reward_manager.all_rewards['success_model'] = MockRewardModel()
     mock_reward_manager.reward_coefficients['success_model'] = 1.0
-    
+
     # Create test inputs
     action_mask = torch.ones(batch_size, seq_len)
     ref_output = (
         torch.zeros(batch_size, seq_len),  # ref_kl
         torch.zeros(batch_size, seq_len),  # ref_log_probs
     )
-    
+
     # Create mixed reward outputs
     expected_success_reward = torch.ones(batch_size, seq_len) * 0.7
-    reward_output = {
+    reward_output: RewardOutput = {
         'test_model': MockAsyncResult(should_timeout=True),  # This times out
-        'success_model': expected_success_reward,  # This succeeds (direct tensor)
+        'success_model':
+            expected_success_reward,  # This succeeds (direct tensor)
     }
-    
+
     # Mock KL controller
     mock_kl_ctl = Mock()
     mock_kl_ctl.value = 0.1
-    
+
     # Test resolve_outputs
     with patch('compose_rl.ppo.reward_manager.log'):
         outputs = mock_reward_manager.resolve_outputs(
@@ -228,21 +257,21 @@ def test_mixed_timeout_and_success(mock_reward_manager):
             kl_ctl=mock_kl_ctl,
             action_mask=action_mask,
         )
-    
+
     # Verify both rewards are in outputs
     assert 'test_model_reward' in outputs
     assert 'success_model_reward' in outputs
-    
+
     # Verify timeout reward is zeros
     timeout_reward = outputs['test_model_reward']
     assert torch.allclose(timeout_reward, torch.zeros_like(timeout_reward))
-    
+
     # Verify success reward has expected values
     success_reward = outputs['success_model_reward']
     assert torch.allclose(success_reward, expected_success_reward * action_mask)
 
 
-def test_make_zero_reward_method():
+def test_make_zero_reward_method() -> None:
     """Test the make_zero_reward static method directly."""
     # Test with various tensor shapes and types
     test_cases = [
@@ -250,20 +279,20 @@ def test_make_zero_reward_method():
         torch.ones(3, 5, dtype=torch.float16),
         torch.ones(1, 15, dtype=torch.int64),
     ]
-    
+
     for ref_tensor in test_cases:
         zero_reward = RewardManager.make_zero_reward(ref_tensor)
-        
+
         # Verify shape, device, and dtype match
         assert zero_reward.shape == ref_tensor.shape
         assert zero_reward.device == ref_tensor.device
         assert zero_reward.dtype == ref_tensor.dtype
-        
+
         # Verify all values are zero
         assert torch.allclose(zero_reward, torch.zeros_like(ref_tensor))
 
 
-def test_timeout_error_import():
+def test_timeout_error_import() -> None:
     """Test that TimeoutError is properly imported from multiprocessing."""
     # This verifies the import fix in the reward_manager.py file
     from compose_rl.ppo.reward_manager import TimeoutError

--- a/tests/test_reward_manager_timeout.py
+++ b/tests/test_reward_manager_timeout.py
@@ -1,0 +1,270 @@
+# Copyright 2024 MosaicML ComposeRL authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for RewardManager async timeout handling.
+
+This test suite validates that the RewardManager properly handles async reward
+computation timeouts by creating zero reward tensors as fallbacks. The tests
+ensure that:
+
+1. When an async reward computation times out, a zero reward tensor is created
+2. The zero reward tensor has the correct shape, device, and dtype
+3. The timeout is properly logged as an error
+4. Multiple rewards (some timing out, some succeeding) are handled correctly
+5. The make_zero_reward helper method works correctly
+"""
+
+import multiprocessing
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+from transformers import PreTrainedTokenizerBase
+
+from compose_rl.ppo.reward_manager import RewardManager
+from compose_rl.reward_learning import InferenceRewardModel
+
+
+class MockAsyncResult(multiprocessing.pool.AsyncResult):
+    """Mock AsyncResult that simulates timeout."""
+    
+    def __init__(self, should_timeout: bool = True, return_value: torch.Tensor = None):
+        # Don't call super().__init__ to avoid complex initialization
+        self.should_timeout = should_timeout
+        self.return_value = return_value
+    
+    def get(self, timeout=None):
+        if self.should_timeout:
+            raise multiprocessing.TimeoutError("Mock timeout")
+        return self.return_value
+
+
+class MockRewardModel(InferenceRewardModel):
+    """Mock reward model with timeout configuration."""
+    
+    BLOCKING_TIMEOUT = 1.0  # 1 second timeout for testing
+    
+    def __init__(self):
+        # Don't call super().__init__ to avoid complex initialization
+        pass
+    
+    def __call__(self, batch):
+        # Mock reward model computation
+        batch_size = batch['zero_rewards'].shape[0]
+        seq_len = batch['zero_rewards'].shape[1]
+        return torch.zeros(batch_size, seq_len)
+
+
+@pytest.fixture
+def mock_reward_manager(tiny_gpt2_tokenizer: PreTrainedTokenizerBase):
+    """Create a minimal RewardManager for testing."""
+    config = {
+        'test_model': {
+            'reward_type': 'inference_reward_model',
+            'reward_coefficient': 1.0,
+            'granularity': 'document',
+        }
+    }
+    
+    ref_config = {
+        'model_config': {
+            'name': 'hf_causal_lm',
+            'pretrained_model_name_or_path': 'gpt2',
+            'pretrained': True,
+        }
+    }
+    
+    # Create RewardManager with minimal initialization
+    with patch.object(RewardManager, 'initialize_composer_model') as mock_init:
+        with patch('compose_rl.ppo.reward_manager.spacy.load') as mock_spacy:
+            mock_ref_model = Mock()
+            mock_init.return_value = mock_ref_model
+            
+            # Mock spacy parser
+            mock_parser = Mock()
+            mock_spacy.return_value = mock_parser
+            
+            # Patch the reward registry and build_reward
+            with patch('compose_rl.ppo.reward_manager.rewards_registry') as mock_registry:
+                with patch('compose_rl.ppo.reward_manager.build_reward') as mock_build:
+                    mock_registry.get.return_value = InferenceRewardModel
+                    mock_reward_model = MockRewardModel()
+                    mock_build.return_value = mock_reward_model
+                    
+                    reward_manager = RewardManager(
+                        config=config,
+                        ref_config=ref_config,
+                        tokenizer=tiny_gpt2_tokenizer,
+                        max_seq_len=32,
+                        fsdp_config=None,
+                        precision='fp32',
+                    )
+                    
+                    # Manually set up the reward model
+                    reward_manager.all_rewards['test_model'] = mock_reward_model
+                    reward_manager.inference_rewards = ['test_model']
+                    
+                    return reward_manager
+
+
+def test_async_timeout_creates_zero_reward(mock_reward_manager):
+    """Test that async timeout creates proper zero reward tensor."""
+    batch_size, seq_len = 2, 10
+    
+    # Create test inputs  
+    action_mask = torch.ones(batch_size, seq_len)
+    ref_output = (
+        torch.zeros(batch_size, seq_len),  # ref_kl
+        torch.zeros(batch_size, seq_len),  # ref_log_probs
+    )
+    
+    # Create reward output with timeout AsyncResult
+    timeout_async_result = MockAsyncResult(should_timeout=True)
+    reward_output = {
+        'test_model': timeout_async_result
+    }
+    
+    # Mock KL controller
+    mock_kl_ctl = Mock()
+    mock_kl_ctl.value = 0.1
+    
+    # Test resolve_outputs with timeout
+    with patch('compose_rl.ppo.reward_manager.log') as mock_log:
+        outputs = mock_reward_manager.resolve_outputs(
+            ref_output=ref_output,
+            reward_output=reward_output,
+            kl_ctl=mock_kl_ctl,
+            action_mask=action_mask,
+        )
+    
+    # Verify error was logged
+    mock_log.error.assert_called_once()
+    error_msg = mock_log.error.call_args[0][0]
+    assert 'Timeout while waiting for test_model reward to finish' in error_msg
+    assert 'Using a default reward of 0' in error_msg
+    
+    # Verify outputs have correct structure
+    assert 'rewards' in outputs
+    assert 'env_rewards' in outputs
+    assert 'test_model_reward' in outputs  # reward name gets _reward suffix
+    
+    # Verify the reward tensor has correct shape and is all zeros
+    reward_tensor = outputs['test_model_reward']
+    assert reward_tensor.shape == (batch_size, seq_len)
+    assert torch.allclose(reward_tensor, torch.zeros_like(reward_tensor))
+    
+    # Verify tensor properties match action_mask
+    assert reward_tensor.device == action_mask.device
+    assert reward_tensor.dtype == action_mask.dtype
+
+
+def test_async_success_works_normally(mock_reward_manager):
+    """Test that non-timeout case works normally."""
+    batch_size, seq_len = 2, 10
+    
+    # Create test inputs
+    action_mask = torch.ones(batch_size, seq_len)
+    ref_output = (
+        torch.zeros(batch_size, seq_len),  # ref_kl
+        torch.zeros(batch_size, seq_len),  # ref_log_probs
+    )
+    
+    # Create successful reward tensor
+    expected_reward = torch.ones(batch_size, seq_len) * 0.5
+    success_async_result = MockAsyncResult(should_timeout=False, return_value=expected_reward)
+    reward_output = {
+        'test_model': success_async_result
+    }
+    
+    # Mock KL controller
+    mock_kl_ctl = Mock()
+    mock_kl_ctl.value = 0.1
+    
+    # Test resolve_outputs without timeout
+    outputs = mock_reward_manager.resolve_outputs(
+        ref_output=ref_output,
+        reward_output=reward_output,
+        kl_ctl=mock_kl_ctl,
+        action_mask=action_mask,
+    )
+    
+    # Verify the reward tensor matches expected values
+    reward_tensor = outputs['test_model_reward']
+    assert reward_tensor.shape == (batch_size, seq_len)
+    assert torch.allclose(reward_tensor, expected_reward * action_mask)
+
+
+def test_mixed_timeout_and_success(mock_reward_manager):
+    """Test scenario with multiple rewards where some timeout and some succeed."""
+    batch_size, seq_len = 2, 10
+    
+    # Add another reward model to the manager
+    mock_reward_manager.all_rewards['success_model'] = MockRewardModel()
+    mock_reward_manager.reward_coefficients['success_model'] = 1.0
+    
+    # Create test inputs
+    action_mask = torch.ones(batch_size, seq_len)
+    ref_output = (
+        torch.zeros(batch_size, seq_len),  # ref_kl
+        torch.zeros(batch_size, seq_len),  # ref_log_probs
+    )
+    
+    # Create mixed reward outputs
+    expected_success_reward = torch.ones(batch_size, seq_len) * 0.7
+    reward_output = {
+        'test_model': MockAsyncResult(should_timeout=True),  # This times out
+        'success_model': expected_success_reward,  # This succeeds (direct tensor)
+    }
+    
+    # Mock KL controller
+    mock_kl_ctl = Mock()
+    mock_kl_ctl.value = 0.1
+    
+    # Test resolve_outputs
+    with patch('compose_rl.ppo.reward_manager.log'):
+        outputs = mock_reward_manager.resolve_outputs(
+            ref_output=ref_output,
+            reward_output=reward_output,
+            kl_ctl=mock_kl_ctl,
+            action_mask=action_mask,
+        )
+    
+    # Verify both rewards are in outputs
+    assert 'test_model_reward' in outputs
+    assert 'success_model_reward' in outputs
+    
+    # Verify timeout reward is zeros
+    timeout_reward = outputs['test_model_reward']
+    assert torch.allclose(timeout_reward, torch.zeros_like(timeout_reward))
+    
+    # Verify success reward has expected values
+    success_reward = outputs['success_model_reward']
+    assert torch.allclose(success_reward, expected_success_reward * action_mask)
+
+
+def test_make_zero_reward_method():
+    """Test the make_zero_reward static method directly."""
+    # Test with various tensor shapes and types
+    test_cases = [
+        torch.ones(2, 10, dtype=torch.float32),
+        torch.ones(3, 5, dtype=torch.float16),
+        torch.ones(1, 15, dtype=torch.int64),
+    ]
+    
+    for ref_tensor in test_cases:
+        zero_reward = RewardManager.make_zero_reward(ref_tensor)
+        
+        # Verify shape, device, and dtype match
+        assert zero_reward.shape == ref_tensor.shape
+        assert zero_reward.device == ref_tensor.device
+        assert zero_reward.dtype == ref_tensor.dtype
+        
+        # Verify all values are zero
+        assert torch.allclose(zero_reward, torch.zeros_like(ref_tensor))
+
+
+def test_timeout_error_import():
+    """Test that TimeoutError is properly imported from multiprocessing."""
+    # This verifies the import fix in the reward_manager.py file
+    from compose_rl.ppo.reward_manager import TimeoutError
+    assert TimeoutError is multiprocessing.TimeoutError

--- a/tests/test_reward_manager_timeout.py
+++ b/tests/test_reward_manager_timeout.py
@@ -46,7 +46,7 @@ class MockAsyncResult(AsyncResult):
             raise multiprocessing.TimeoutError('Mock timeout')
         if self.return_value is None:
             # Return a default tensor if none provided
-            return torch.zeros(2, 10)
+            return torch.ones(2, 10)
         return self.return_value
 
 
@@ -269,31 +269,3 @@ def test_mixed_timeout_and_success(mock_reward_manager: RewardManager) -> None:
     # Verify success reward has expected values
     success_reward = outputs['success_model_reward']
     assert torch.allclose(success_reward, expected_success_reward * action_mask)
-
-
-def test_make_zero_reward_method() -> None:
-    """Test the make_zero_reward static method directly."""
-    # Test with various tensor shapes and types
-    test_cases = [
-        torch.ones(2, 10, dtype=torch.float32),
-        torch.ones(3, 5, dtype=torch.float16),
-        torch.ones(1, 15, dtype=torch.int64),
-    ]
-
-    for ref_tensor in test_cases:
-        zero_reward = RewardManager.make_zero_reward(ref_tensor)
-
-        # Verify shape, device, and dtype match
-        assert zero_reward.shape == ref_tensor.shape
-        assert zero_reward.device == ref_tensor.device
-        assert zero_reward.dtype == ref_tensor.dtype
-
-        # Verify all values are zero
-        assert torch.allclose(zero_reward, torch.zeros_like(ref_tensor))
-
-
-def test_timeout_error_import() -> None:
-    """Test that TimeoutError is properly imported from multiprocessing."""
-    # This verifies the import fix in the reward_manager.py file
-    from compose_rl.ppo.reward_manager import TimeoutError
-    assert TimeoutError is multiprocessing.TimeoutError


### PR DESCRIPTION
Before this PR, reward computation was susceptible to hanging and then eventually timing out the run on the next distributed call. This PR adds a (configurable) timeout to the async join to prevent this situation. It uses zero reward for timed out evals (open to other opinions of what should happen here, and we can make this per reward configurable if needed).

Before this PR, I would launch 4 runs, and they would all eventually fail with a timeout (~2 would fail within 30 minutes). Now I have four runs that have been going for more than an hour, will keep them running for a while. Example run: `test-nccl-errors-logs-4-4-usbIaW`