### PR TITLE
Skip initial vLLM weight load.

### DIFF
--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -185,6 +185,7 @@ def create_vllm_engines(
     enable_prefix_caching: bool,
     max_model_len: int,
     vllm_gpu_memory_utilization: float = 0.9,
+    load_format: str = 'dummy',
 ):
     """Creates vllm engines.
 
@@ -198,6 +199,7 @@ def create_vllm_engines(
         enable_prefix_caching (bool): Whether to enable prefix caching
         max_model_len (int): Maximum model length
         vllm_gpu_memory_utilization (float): GPU memory utilization for vllm
+        load_format (str): Load format for the model, defaults to 'dummy'
     """
     bundles = [{
         'GPU': 1,
@@ -261,6 +263,7 @@ def create_vllm_engines(
                 num_gpus=1,  # type: ignore
                 noset_visible_devices= # type: ignore
                 ray_noset_visible_devices(),
+                load_format=load_format,  # type: ignore
             ),
         )
 

--- a/compose_rl/utils/vllm_utils.py
+++ b/compose_rl/utils/vllm_utils.py
@@ -247,21 +247,21 @@ def create_vllm_engines(
                 revision=revision,  # type: ignore
                 tokenizer_revision=revision,  # type: ignore
                 trust_remote_code=True,  # type: ignore
-                worker_extension_cls= # type: ignore
+                worker_extension_cls=  # type: ignore
                 'compose_rl.utils.vllm_utils.WorkerWrap',
                 tensor_parallel_size=tensor_parallel_size,  # type: ignore
                 enforce_eager=enforce_eager,  # type: ignore
                 dtype='bfloat16',  # type: ignore
                 seed=seed + i,  # type: ignore
-                distributed_executor_backend= # type: ignore
+                distributed_executor_backend=  # type: ignore
                 distributed_executor_backend,
                 enable_prefix_caching=enable_prefix_caching,  # type: ignore
                 max_model_len=max_model_len,  # type: ignore
-                gpu_memory_utilization= # type: ignore
+                gpu_memory_utilization=  # type: ignore
                 vllm_gpu_memory_utilization,
                 bundle_indices=bundle_indices,  # type: ignore
                 num_gpus=1,  # type: ignore
-                noset_visible_devices= # type: ignore
+                noset_visible_devices=  # type: ignore
                 ray_noset_visible_devices(),
                 load_format=load_format,  # type: ignore
             ),


### PR DESCRIPTION
Since we sync the weights before doing any computation, we don't need vllm to also download the weights. This sets the default `load_format` for vllm to `dummy` (random init) to avoid this download. This also allows us to use pytorch sharded checkpoints + meta init to load the weights (which then get broadcast to the vllm engines before any computation occurs).

Evals and loss are initially the same:
<img width="460" alt="Screenshot 2025-06-10 at 2 25 27 PM" src="https://github.com/user-attachments/assets/24c66828-6e67-4c7d-beb1-006560a43b40" />
<img width="1204" alt="Screenshot 2025-06-10 at 2 25 20 PM" src="https://github.com/user-attachments/assets/719c3086-94a4-4191-86ee-1e98838008dd" />
