### PR TITLE
Fix memory leak

### DIFF
--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -160,10 +160,14 @@ class RewardManager:
         self.granularity_types = list(set(self.granularities.values()))
 
         self.pool = None
+        self._num_reward_procs = None
         if self.inference_rewards or self.functional_rewards:
+            self._num_reward_procs = (
+                len(self.inference_rewards) +
+                len(self.functional_rewards)
+            )
             self.pool = Pool(
-                processes=len(self.inference_rewards) +
-                len(self.functional_rewards),
+                processes=self._num_reward_procs,
                 context=get_context('spawn'),
             )
 
@@ -580,6 +584,7 @@ class RewardManager:
         resolved_reward_outputs: dict[str, torch.Tensor] = {}
         bad_end_generation_mask = None
         bad_end_generation_name = None
+        encountered_timeout = False
         for name, subreward in reward_output.items():
             if isinstance(subreward, AsyncResult):
                 try:
@@ -587,6 +592,7 @@ class RewardManager:
                         timeout=self.all_rewards[name].BLOCKING_TIMEOUT,
                     )
                 except TimeoutError:
+                    encountered_timeout = True
                     log.error(
                         f'Timeout while waiting for {name} reward to finish. ' +
                         'This may indicate a problem with the reward. Using a default reward of 0.',
@@ -607,6 +613,18 @@ class RewardManager:
                 bad_end_generation_mask = bad_end_generation_mask.to(
                     device=device,
                 )
+
+        # Rather than trying to signal to the stuck process, or do anything more careful,
+        # since we know we are fully done with reward computation, we can just recreate the pool
+        # to ensure that all processes are cleaned up and we can continue without resources leaking.
+        if encountered_timeout and self.pool is not None:
+            self.pool.terminate()
+            self.pool.join()
+
+            self.pool = Pool(
+                processes=self._num_reward_procs,
+                context=get_context('spawn'),
+            )
 
         ref_kl = ref_output[0].to(device=device)
         ref_log_probs = ref_output[1].to(device=device)

--- a/compose_rl/ppo/reward_manager.py
+++ b/compose_rl/ppo/reward_manager.py
@@ -163,8 +163,7 @@ class RewardManager:
         self._num_reward_procs = None
         if self.inference_rewards or self.functional_rewards:
             self._num_reward_procs = (
-                len(self.inference_rewards) +
-                len(self.functional_rewards)
+                len(self.inference_rewards) + len(self.functional_rewards)
             )
             self.pool = Pool(
                 processes=self._num_reward_procs,


### PR DESCRIPTION
Previous PR resolved the hanging reward issue, but that left behind a process that continued to grow in memory usage. This PR resolves that with the blunt solution of just recreating the multiprocessing pool if any rewards time out.

Memory growth is stable:
<img width="401" alt="Screenshot 2025-06-11 at 2 21 38 PM" src="https://github.com/user-attachments/assets/6784d7e2-3792-4c95-adbb-a355e2500255" />

At least one run had a timeout and was able to proceed:
```
(dev) daniel.king@Q734G6KDXN github % l long-running-rl-4-3-zjNFab --global-gpu-rank 3 | grep ERROR
2025-06-11 20:55:48,535: ERROR: compose_rl.ppo.reward_manager: Timeout while waiting for math_verifier reward to finish. This may indicate a problem with the reward. Using a default reward of 0.
```