### PR TITLE
Removed Compatibility directories

### DIFF
--- a/compose_rl/dpo/__init__.py
+++ b/compose_rl/dpo/__init__.py
@@ -1,2 +1,0 @@
-# Copyright 2024 MosaicML ComposeRL authors
-# SPDX-License-Identifier: Apache-2.0

--- a/compose_rl/dpo/model_methods.py
+++ b/compose_rl/dpo/model_methods.py
@@ -1,7 +1,0 @@
-# Copyright 2024 MosaicML ComposeRL authors
-# SPDX-License-Identifier: Apache-2.0
-
-from compose_rl.algorithms.offline.model_methods import \
-    PairwiseOfflineEnum as DPOEnum  # pyright: ignore
-from compose_rl.algorithms.offline.model_methods import \
-    pairwise_offline_loss as dpo_loss  # pyright: ignore

--- a/compose_rl/ppo/__init__.py
+++ b/compose_rl/ppo/__init__.py
@@ -1,5 +1,0 @@
-# Copyright 2024 MosaicML ComposeRL authors
-# SPDX-License-Identifier: Apache-2.0
-
-from compose_rl.algorithms.online.callback import \
-    OnPolicyCallback as PPOCallback  # pyright: ignore


### PR DESCRIPTION
Updated other repositories with `compose_rl` dependencies. No longer need the extra directories for the deprecated import names.