### PR TITLE
Allow reference checkpoint to be both callback and load_path

### DIFF
--- a/compose_rl/algorithms/offline/callback.py
+++ b/compose_rl/algorithms/offline/callback.py
@@ -60,7 +60,8 @@ class ReferencePolicyCallback(CallbackWithConfig):
                 strict_model_weights=callback.strict_model_weights,
                 ignore_keys=callback.ignore_keys,
                 event=callback.event,
-            ) for callback in state.callbacks
+            )
+            for callback in state.callbacks
             if isinstance(callback, LoadCheckpoint)
         ]
 

--- a/compose_rl/algorithms/offline/callback.py
+++ b/compose_rl/algorithms/offline/callback.py
@@ -54,7 +54,13 @@ class ReferencePolicyCallback(CallbackWithConfig):
         # The base model checkpoint may have been supplied by a LoadCheckpoint callback,
         # so we need to check and apply that checkpoint to the reference model.
         load_checkpoint_callbacks = [
-            copy.deepcopy(callback) for callback in state.callbacks
+            LoadCheckpoint(
+                load_path=callback.load_path,
+                load_weights_only=callback.load_weights_only,
+                strict_model_weights=callback.strict_model_weights,
+                ignore_keys=callback.ignore_keys,
+                event=callback.event,
+            ) for callback in state.callbacks
             if isinstance(callback, LoadCheckpoint)
         ]
 

--- a/compose_rl/algorithms/offline/callback.py
+++ b/compose_rl/algorithms/offline/callback.py
@@ -11,8 +11,6 @@ from composer import Trainer
 from composer.callbacks import LoadCheckpoint
 from composer.core import State, get_precision_context
 from composer.loggers import Logger
-from composer.models.huggingface import HuggingFaceModel
-from composer.utils.checkpoint import load_checkpoint
 from llmfoundry.interfaces import CallbackWithConfig
 from llmfoundry.utils import build_composer_model
 # pyright does not recognize process_init_device though it is a declared export

--- a/compose_rl/algorithms/offline/callback.py
+++ b/compose_rl/algorithms/offline/callback.py
@@ -51,52 +51,24 @@ class ReferencePolicyCallback(CallbackWithConfig):
 
         original_load_path = self.train_config.get('load_path', None)
 
+        # The base model checkpoint may have been supplied by a LoadCheckpoint callback,
+        # so we need to check and apply that checkpoint to the reference model.
+        load_checkpoint_callbacks = [
+            copy.deepcopy(callback) for callback in state.callbacks
+            if isinstance(callback, LoadCheckpoint)
+        ]
+
         # For HF checkpoint, load_path is unset and should be handled in llmfoundry code.
         # Create a Trainer object to load model into FSDP
-        fake_trainer = Trainer(
+        _ = Trainer(
             model=self.reference_model,
             parallelism_config={'fsdp': state.fsdp_config},
             precision=state.precision,
             load_weights_only=True,
             load_strict_model_weights=False,
             load_path=original_load_path,
+            callbacks=load_checkpoint_callbacks,
         )
-
-        # The base model checkpoint may have been supplied by a LoadCheckpoint callback,
-        # so we need to check and apply that checkpoint to the reference model.
-        load_checkpoint_callbacks = [
-            callback for callback in state.callbacks
-            if isinstance(callback, LoadCheckpoint)
-        ]
-
-        if original_load_path is not None and len(
-            load_checkpoint_callbacks,
-        ) > 0:
-            raise ValueError(
-                'Cannot use `load_path` in the train config when using `LoadCheckpoint` callback. '
-                + 'Please remove `load_path` from the train config.',
-            )
-
-        # For any LoadCheckpoint callbacks we found, we will load the checkpoint into the reference model.
-        # If none are found, this for loop is a no-op.
-        for load_checkpoint_callback in load_checkpoint_callbacks:
-            assert isinstance(self.reference_model, HuggingFaceModel)
-
-            # If using PEFT, we need to _not_ filter the state dict to only include the PEFT weights.
-            # This is so the checkpoint can load the base model weights. Since the reference model is
-            # not being update, we don't need to respect the `should_save_peft_only` flag from the original model
-            # and can just hardcode it to False.
-            self.reference_model.should_save_peft_only = False
-            load_checkpoint(
-                path=load_checkpoint_callback.parsed_path,
-                state=fake_trainer.state,
-                logger=logger,
-                object_store=load_checkpoint_callback.load_object_store,
-                strict_model_weights=load_checkpoint_callback.
-                strict_model_weights,
-                ignore_keys=load_checkpoint_callback.ignore_keys,
-                load_weights_only=load_checkpoint_callback.load_weights_only,
-            )
 
     def before_forward(self, state: State, logger: Logger) -> Optional[int]:
         # Before every batch we need to do a forwards pass over the reference model

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -17,8 +17,10 @@ from composer.utils import checkpoint, dist
 from torch.utils.data import DataLoader
 from transformers import PreTrainedModel, PreTrainedTokenizer
 
-from compose_rl.algorithms.offline import (ComposerHFPairwiseOfflinePolicyLM,
-                                           ComposerMPTPairwiseOfflinePolicyLM,)
+from compose_rl.algorithms.offline import (
+    ComposerHFPairwiseOfflinePolicyLM,
+    ComposerMPTPairwiseOfflinePolicyLM,
+)
 from compose_rl.algorithms.offline.callback import ReferencePolicyCallback
 from compose_rl.data import pairwise_preference_dataset_collate_fn
 from tests.common import PairwisePreference, world_size
@@ -49,7 +51,7 @@ def test_load_checkpoint_with_offline_callback(
         load_path=str(composer_checkpoint_path),
     )
     load_checkpoint_callback._load = MagicMock(
-        wraps=load_checkpoint_callback._load
+        wraps=load_checkpoint_callback._load,
     )
 
     assert load_checkpoint_callback.parsed_path == str(composer_checkpoint_path)
@@ -63,14 +65,15 @@ def test_load_checkpoint_with_offline_callback(
         'model': model_config,
     }
     reference_policy_callback = ReferencePolicyCallback(
-        train_config=train_config
+        train_config=train_config,
     )
 
     with patch(
         'composer.utils.checkpoint.load_checkpoint',
-        wraps=checkpoint.load_checkpoint
+        wraps=checkpoint.load_checkpoint,
     ) as mock_load_checkpoint, patch(
-        'compose_rl.algorithms.offline.callback.Trainer', wraps=Trainer
+        'compose_rl.algorithms.offline.callback.Trainer',
+        wraps=Trainer,
     ) as mock_trainer:
         trainer = Trainer(
             model=model,

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1,24 +1,80 @@
 # Copyright 2024 MosaicML ComposeRL authors
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import os
 import pathlib
 from functools import partial
 from typing import Any, Optional
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from composer import Trainer
+from composer.callbacks import LoadCheckpoint
 from composer.loggers import InMemoryLogger
 from composer.optim import DecoupledAdamW
-from composer.utils import dist
+from composer.utils import dist, checkpoint
 from torch.utils.data import DataLoader
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer, PreTrainedModel
 
-from compose_rl.algorithms.offline import ComposerMPTPairwiseOfflinePolicyLM
+from compose_rl.algorithms.offline import ComposerMPTPairwiseOfflinePolicyLM, ComposerHFPairwiseOfflinePolicyLM
 from compose_rl.algorithms.offline.callback import ReferencePolicyCallback
 from compose_rl.data import pairwise_preference_dataset_collate_fn
 from tests.common import PairwisePreference, world_size
+
+def test_load_checkpoint_with_offline_callback(
+    tiny_gpt2_tokenizer: PreTrainedTokenizer,
+    tiny_gpt2_model: PreTrainedModel,
+    tmp_path: pathlib.Path,
+):
+    tiny_gpt2_model.save_pretrained(tmp_path / 'hf_model')
+    tiny_gpt2_tokenizer.save_pretrained(tmp_path / 'hf_model')
+
+    composer_checkpoint_path = tmp_path / 'checkpoint.pt'
+    model = ComposerHFPairwiseOfflinePolicyLM(
+        tokenizer=tiny_gpt2_tokenizer,
+        pretrained_model_name_or_path=str(tmp_path / 'hf_model'),
+    )
+    trainer = Trainer(
+        model=model,
+    )
+
+    trainer.save_checkpoint(
+        str(composer_checkpoint_path),
+    )
+
+    load_checkpoint_callback = LoadCheckpoint(
+        load_path=str(composer_checkpoint_path)
+    )
+    load_checkpoint_callback._load = MagicMock(wraps=load_checkpoint_callback._load)
+
+    assert load_checkpoint_callback.parsed_path == str(composer_checkpoint_path)
+
+    model_config = {
+        'name': 'hf_pairwise_offline_lm',
+        'pretrained_model_name_or_path': str(tmp_path / 'hf_model'),
+        'tokenizer': tiny_gpt2_tokenizer,
+    }
+    train_config = {
+        'model': model_config,
+    }
+    reference_policy_callback = ReferencePolicyCallback(train_config=train_config)
+
+    with patch('composer.utils.checkpoint.load_checkpoint', wraps=checkpoint.load_checkpoint) as mock_load_checkpoint, patch('compose_rl.algorithms.offline.callback.Trainer', wraps=Trainer) as mock_trainer:
+        trainer = Trainer(
+            model=model,
+            callbacks=[load_checkpoint_callback, reference_policy_callback],
+            load_path=str(composer_checkpoint_path),
+        )
+        mock_load_checkpoint.assert_called_once()
+        mock_trainer.assert_called_once()
+        comparison_dict = copy.deepcopy(load_checkpoint_callback.__dict__)
+        # Remove the _load added by the mock
+        comparison_dict.pop('_load')
+        # The callback passed into the dummy trainer should match the original callback
+        assert mock_trainer.call_args.kwargs['callbacks'][0].__dict__ == comparison_dict
+
+    load_checkpoint_callback._load.assert_called_once()
 
 
 def test_reference_policy_callback_forward(


### PR DESCRIPTION
Follow up to https://github.com/databricks/compose-rl/pull/80, turns out we do actually need to specify both load_path and load a checkpoint via the LoadCheckpoint callback. This can occur if the load_path checkpoint contains previously trained PEFT weights, while the LoadCheckpoint callback would contain the base weights.

This version of the code is a bit cleaner anyway because it uses the callback as a callback instead of introspecting it and calling the load function manually.

Manual testing:
Main branch, no callback: `lc-2-baseline-1-ab2474`
This branch, with callback, no load_path: `lc-2-condition-3-6NLvT8`
This branch, with callback, with load_path: `lc-2-condition-ckpt-4-43h1KP`

In addition to verifying in the logs that the right checkpoints are loaded, we can see that baseline and condition overlap, while "with load_path" has a different loss curve since it starts from an already trained lora checkpoint.
<img width="644" alt="Screenshot 2025-06-25 at 4 29 34 PM" src="https://github.com/user-attachments/assets/63268fa4-ba3b-453c-866c-6ef8872863c7" />

I also checked one counterfactual to confirm that the intended checkpoints were being loaded.
This branch, no callback: `lc-2-no-base-1-5ejGEF`, this results in nan loss because the model weights aren't properly unmetad
