### PR TITLE
vLLM Chat Conversion

### DIFF
--- a/compose_rl/algorithms/online/callback.py
+++ b/compose_rl/algorithms/online/callback.py
@@ -34,8 +34,8 @@ from compose_rl.algorithms.online.generation_utils import (
     create_vllm_engines,
     hf_generate,
     init_process_group,
-    vllm_generate,
     vllm_chat,
+    vllm_generate,
 )
 from compose_rl.algorithms.online.model import (
     ComposerHFPolicyLM,
@@ -485,7 +485,9 @@ class OnPolicyCallback(CallbackWithConfig):
             elif vllm_function == 'generate':
                 self.vllm_generate_function = vllm_generate
             else:
-                raise ValueError("vllm_generate_function needs to be either `generate` or `chat`")
+                raise ValueError(
+                    'vllm_generate_function needs to be either `generate` or `chat`',
+                )
 
             self.vllm_model_name = train_config['model'][
                 'pretrained_model_name_or_path']

--- a/compose_rl/algorithms/online/generation_utils/__init__.py
+++ b/compose_rl/algorithms/online/generation_utils/__init__.py
@@ -3,8 +3,8 @@
 
 from compose_rl.algorithms.online.generation_utils.generation_utils import (
     hf_generate,
-    vllm_generate,
     vllm_chat,
+    vllm_generate,
 )
 from compose_rl.algorithms.online.generation_utils.vllm_utils import (
     broadcast_to_vllm,

--- a/compose_rl/algorithms/online/generation_utils/__init__.py
+++ b/compose_rl/algorithms/online/generation_utils/__init__.py
@@ -4,6 +4,7 @@
 from compose_rl.algorithms.online.generation_utils.generation_utils import (
     hf_generate,
     vllm_generate,
+    vllm_chat,
 )
 from compose_rl.algorithms.online.generation_utils.vllm_utils import (
     broadcast_to_vllm,
@@ -17,4 +18,5 @@ __all__ = [
     'init_process_group',
     'hf_generate',
     'vllm_generate',
+    'vllm_chat',
 ]

--- a/compose_rl/algorithms/online/generation_utils/generation_utils.py
+++ b/compose_rl/algorithms/online/generation_utils/generation_utils.py
@@ -249,3 +249,187 @@ def vllm_generate(
         f'It took {time.time() - start_gen_time} to generate {num_tokens_generated} tokens',
     )
     return sequences
+
+
+def vllm_chat(
+    vllm_engines: list,
+    batch: dict,
+    max_gen_len: int,
+    generation_kwargs: dict,
+    tokenizer: Tokenizer,
+) -> torch.Tensor:
+    """Run vllm chat on the prompts using messages.
+
+    Runs generate over a set of sequences in the batch. It also does extra computation
+    that is required for later loss computation.
+
+    Args:
+        vllm_engines (list): List of vllm engines to run generate over.
+        batch (dict): The batch of data to run generate over.
+        max_gen_len (int): Maximum generation length.
+        generation_kwargs (dict): Generation keyword arguments.
+        tokenizer (Tokenizer): The actor critic's tokenizer.
+
+    Returns:
+        sequences (tensor): Tensor containing the prompt and generated sequences.
+            The shape of the tensor is [batch_size, prompt_len + max_gen_len].
+    """
+    if type(vllm_engines) != list:
+        raise TypeError(
+            f'vllm_engines must be a list. Instead got {type(vllm_engines)=}',
+        )
+    # 1. Gather all prompts from all ranks
+    # 2. Run generate over all prompts in one go
+    # 3. Scatter the generated responses back to the correct rank
+    # 4. Save the tokenized sequences in the batch for future use
+    pad_token_id = tokenizer.pad_token_id  # type: ignore
+    # Pull the necessary variables from the batch and self
+    cur_device = batch['prompt'].device
+    prompt_tokens = batch['prompt']
+    messages = batch['messages']
+
+    prompt_all_gather_start_time = time.time()
+
+    all_batched_prompts = dist.all_gather_object(prompt_tokens)
+    all_batched_messages = dist.all_gather_object(messages)
+    batch_sizes = [len(batch) for batch in all_batched_prompts]
+
+    log.info(
+        f'took : {time.time() - prompt_all_gather_start_time} to gather prompts',
+    )
+    all_prompts = [prompt for batch in all_batched_prompts for prompt in batch]
+    all_messages = [message for batch in all_batched_messages for message in batch]
+    assert len(all_prompts) == len(all_messages)
+
+    start_gen_time = time.time()
+    if dist.get_global_rank() == 0:
+        futs = []
+        sampling_params = {
+            'temperature': generation_kwargs.get('temperature', 1.0),
+            'top_p': generation_kwargs.get('top_p', 1.0),
+            'top_k': generation_kwargs.get('top_k', -1),
+            'max_tokens': max_gen_len,
+        }
+
+        # We have to remove all pad tokens here. Keep here to check
+        all_prompts = [[
+            token
+            for token in prompt.detach().cpu().tolist()
+            if token != pad_token_id
+        ]
+                       for prompt in all_prompts]
+
+        # Generate with vllm
+        # Calculate the base batch size
+        vllm_batch_size = len(all_messages) // len(vllm_engines)
+        # Calculate the remainder (messages that don't fit evenly)
+        remainder = len(all_messages) % len(vllm_engines)
+
+        start_idx = 0
+        for i, engine in enumerate(vllm_engines):
+            # Assign one extra prompt to the first 'remainder' engines
+            if i < remainder:
+                end_idx = start_idx + vllm_batch_size + 1
+            else:
+                end_idx = start_idx + vllm_batch_size
+
+            cur_messages = all_messages[start_idx:end_idx]
+
+            futs.append(
+                engine.chat.remote(
+                    messages=cur_messages,
+                    sampling_params=sampling_params,
+                ),
+            )
+
+            # Update the start index for the next iteration
+            start_idx = end_idx
+
+        start_time = time.time()
+        results = ray.get(futs)
+        all_responses, all_vllm_prompts = [], []
+
+        # Get all of the ray futures
+        for i, result in enumerate(results):
+            # Each result is a list of responses this assumes one output per input
+            all_responses.extend([resp.outputs[0].token_ids for resp in result])
+
+            # Get prompt ids processed by vllm for checks
+            all_vllm_prompts.extend([resp.prompt_token_ids for resp in result])
+
+        log.info(
+            f'took: {time.time() - start_time} to gather futures',
+        )
+
+        # Remove pad tokens from vllm prompts
+        all_vllm_prompts = [[
+            token
+            for token in prompt
+            if token != pad_token_id
+        ]
+                       for prompt in all_vllm_prompts]
+
+        # Checking vllm prompts with all prompts
+        assert all_prompts == all_vllm_prompts
+
+        # Distribute padded responses back to the correct device
+        split_responses = []
+        start = 0
+        for size in batch_sizes:
+            split_responses.append(
+                all_responses[start:start + size],
+            )
+            start += size
+    else:
+        # Remove the memory from all gather as they are only used for the first rank
+        all_batched_prompts = None
+        all_prompts = None
+        split_responses = None
+
+    # Do another garbage collection and empty the cache
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    dist.barrier()
+
+    # Scatter the generated responses back to the correct rank
+    local_responses = [None]
+    start_time = time.time()
+    torch.distributed.scatter_object_list(
+        local_responses,
+        split_responses,
+        src=0,
+    )
+    local_responses = local_responses[0]
+
+    log.info(f'took: {time.time() - start_time} to scatter prompts')
+
+    # Pad the responses to the maximum length
+    max_vllm_generated_len = max([
+        len(response) for response in local_responses  # type: ignore
+    ])
+    padded_responses = []
+    for sequence in local_responses:  # type: ignore
+        sequence = list(sequence)
+        if len(sequence) < max_vllm_generated_len:
+            sequence = sequence + [
+                pad_token_id,
+            ] * (max_vllm_generated_len - len(sequence))
+
+        padded_responses.append(sequence)
+
+    # Convert the padded responses to a tensor
+    padded_responses = torch.tensor(
+        padded_responses,
+        dtype=prompt_tokens.dtype,
+        device=cur_device,
+    )
+
+    # Construct full sequences from the prompt and padded responses
+    sequences = torch.cat([prompt_tokens, padded_responses], dim=-1)
+    num_tokens_generated = sequences.size(1) - prompt_tokens.size(1)
+    log.info(
+        f'It took {time.time() - start_gen_time} to generate {num_tokens_generated} tokens',
+    )
+    return sequences

--- a/compose_rl/algorithms/online/generation_utils/generation_utils.py
+++ b/compose_rl/algorithms/online/generation_utils/generation_utils.py
@@ -298,7 +298,9 @@ def vllm_chat(
         f'took : {time.time() - prompt_all_gather_start_time} to gather prompts',
     )
     all_prompts = [prompt for batch in all_batched_prompts for prompt in batch]
-    all_messages = [message for batch in all_batched_messages for message in batch]
+    all_messages = [
+        message for batch in all_batched_messages for message in batch
+    ]
     assert len(all_prompts) == len(all_messages)
 
     start_gen_time = time.time()
@@ -363,11 +365,8 @@ def vllm_chat(
 
         # Remove pad tokens from vllm prompts
         all_vllm_prompts = [[
-            token
-            for token in prompt
-            if token != pad_token_id
-        ]
-                       for prompt in all_vllm_prompts]
+            token for token in prompt if token != pad_token_id
+        ] for prompt in all_vllm_prompts]
 
         # Checking vllm prompts with all prompts
         assert all_prompts == all_vllm_prompts


### PR DESCRIPTION
Added `vllm_chat` as an additional function that uses`llm.chat` instead of `llm.generate`. 
Details: 
- `vllm_generate_function = {chat, generate}` config key added to choose between `vllm_generate` or `vllm_chat`
- `vllm_chat` compares prompts used in training and prompts used internally by `vllm` to ensure there is no difference across train and test tokens