### PR TITLE
Add prefix caching

### DIFF
--- a/compose_rl/algorithms/online/generation_utils/vllm_actor.py
+++ b/compose_rl/algorithms/online/generation_utils/vllm_actor.py
@@ -79,9 +79,9 @@ class LLMRayActor:
             log.info(f'sampling_params is: {sampling_params}')
 
         return self.llm.generate(
-            sampling_params=sampling_params,
             *args,
             **kwargs,
+            sampling_params=sampling_params,
         )
 
     def chat(self, *args: Any, **kwargs: Any):
@@ -129,5 +129,5 @@ class LLMRayActor:
             args=(name, dtype, shape, empty_cache),
         )
 
-    def reset_prefix_caching(self):
+    def reset_prefix_cache(self):
         self.llm.llm_engine.reset_prefix_cache()

--- a/compose_rl/algorithms/online/generation_utils/vllm_actor.py
+++ b/compose_rl/algorithms/online/generation_utils/vllm_actor.py
@@ -128,3 +128,6 @@ class LLMRayActor:
             'update_weight',
             args=(name, dtype, shape, empty_cache),
         )
+
+    def reset_prefix_caching(self):
+        self.llm.llm_engine.reset_prefix_cache()

--- a/compose_rl/algorithms/online/generation_utils/vllm_utils.py
+++ b/compose_rl/algorithms/online/generation_utils/vllm_utils.py
@@ -380,6 +380,7 @@ def broadcast_to_vllm(
     model_update_group: Optional[torch.distributed.ProcessGroup],
     batch: dict[str, torch.Tensor],
     loss_type: OnPolicyEnum = OnPolicyEnum.PPO,
+    enable_prefix_caching: bool = False,
 ):
     """Broadcast model weights to all vllm engines.
 
@@ -388,7 +389,8 @@ def broadcast_to_vllm(
         vllm_engines (list): List of vllm engines
         model_update_group (torch.distributed.ProcessGroup): The process group for model updates
         batch (dict[str, torch.Tensor]): The batch to use for the forward pass
-        loss_type (str): The loss type which decides whether to use critic-free or not. Defaults to "ppo".
+        loss_type (str): The loss type which decides whether to use critic-free or not. Defaults to `ppo`.
+        enable_prefix_caching (bool): Whether to enable prefix caching. Defaults to `False`.
     """
     # avoid OOM
     torch.cuda.empty_cache()
@@ -406,7 +408,14 @@ def broadcast_to_vllm(
         raise ValueError(
             f'Unsupported loss type: {loss_type}. Supported types are: ppo, grpo',
         )
+
     refss = []
+    cache_reset_refss = []
+    if enable_prefix_caching and dist.get_global_rank() == 0:
+        cache_reset_refss = [
+            engine.reset_prefix_cache.remote() for engine in vllm_engines
+        ]
+
     # This is needed to get the correct model device
     cur_device = batch['prompt'].device
 
@@ -516,6 +525,8 @@ def broadcast_to_vllm(
     log.info(f'for loop took: {time.time() - start_time}')
     start_time = time.time()
     ray.get(refss)
+    if enable_prefix_caching:
+        ray.get(cache_reset_refss)
     log.info(f'ray refs took: {time.time() - start_time}')
     log.info(f'update time is: {update_time}')
     log.info(f'number of parameters updated is: {count}')


### PR DESCRIPTION
- Enables prefix caching for generations

Run names (with and without change):
- main: `qwen-main-6VK0xI`
- branch: `qwen-pc-NzE7Rl`

Rewards
<img width="442" alt="Screenshot 2025-07-09 at 15 25 43" src="https://github.com/user-attachments/assets/53ba8d42-ea80-4a26-8393-f5f96f4068ee" />

Scores
<img width="442" alt="Screenshot 2025-07-09 at 15 26 08" src="https://github.com/user-attachments/assets/d98638de-8710-4edc-988b-70c9f1f947e5" />

Time estimates (small speedups for bsz 64 + 8 generations per prompt)
<img width="1816" alt="Screenshot 2025-07-09 at 15 27 01" src="https://github.com/user-attachments/assets/56dc67e0-1649-4906-b963-f0ae1904e993" />

