### PR TITLE
Updating `.pre-commit-config.yaml` to follow Composer's version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,30 +12,42 @@ repos:
   hooks:
   - id: yapf
     name: yapf
-    description: A formatter for Python files.
+    description: "A formatter for Python files."
     entry: yapf
-    args: [-i, -vv, -p]       # inplace
+    args: [-i, -vv, -p]  # inplace
     language: python
     types: [python]
     additional_dependencies:
-    - toml
-- repo: https://github.com/hadialqattan/pycln
-  rev: v2.5.0
-  hooks:
-  - id: pycln
-    args: [. --all]
+    - "toml"
 - repo: https://github.com/pycqa/isort
   hooks:
   - id: isort
   rev: 5.12.0
+- repo: https://github.com/PyCQA/pydocstyle
+  hooks:
+  - id: pydocstyle
+    name: pydocstyle
+    entry: pydocstyle
+    language: python
+    types: [python]
+    additional_dependencies:
+    - "toml"
+  rev: 6.1.1
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.28.0
+  hooks:
+  - id: yamllint
+    name: yamllint
+    description: This hook runs yamllint.
+    entry: yamllint
+    language: python
+    types: [file, yaml]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:
   - id: check-added-large-files
   - id: check-ast
   - id: check-builtin-literals
-    args:
-    - --no-allow-dict-kwargs
   - id: check-case-conflict
   - id: check-docstring-first
   - id: check-executables-have-shebangs
@@ -54,7 +66,6 @@ repos:
   - id: check-yaml
   - id: debug-statements
   - id: destroyed-symlinks
-  - id: double-quote-string-fixer
   - id: end-of-file-fixer
   - id: fix-byte-order-marker
   - id: mixed-line-ending
@@ -70,31 +81,6 @@ repos:
     - "#"
     - --allow-past-years
     types: [python]
-- repo: https://github.com/PyCQA/docformatter
-  rev: v1.5.0
-  hooks:
-  - id: docformatter
-    args: [--in-place, --wrap-summaries=80, --wrap-descriptions=80]
-- repo: https://github.com/PyCQA/pydocstyle
-  hooks:
-  - id: pydocstyle
-    name: pydocstyle
-    entry: pydocstyle
-    language: python
-    types: [python]
-    exclude: (.ci|.github)
-    additional_dependencies:
-    - toml
-  rev: 6.1.1
-- repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.28.0
-  hooks:
-  - id: yamllint
-    name: yamllint
-    description: This hook runs yamllint.
-    entry: yamllint
-    language: python
-    types: [file, yaml]
 - repo: local
   hooks:
   - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,42 +12,30 @@ repos:
   hooks:
   - id: yapf
     name: yapf
-    description: "A formatter for Python files."
+    description: A formatter for Python files.
     entry: yapf
-    args: [-i, -vv, -p]  # inplace
+    args: [-i, -vv, -p]       # inplace
     language: python
     types: [python]
     additional_dependencies:
-    - "toml"
+    - toml
+- repo: https://github.com/hadialqattan/pycln
+  rev: v2.5.0
+  hooks:
+  - id: pycln
+    args: [. --all]
 - repo: https://github.com/pycqa/isort
   hooks:
   - id: isort
   rev: 5.12.0
-- repo: https://github.com/PyCQA/pydocstyle
-  hooks:
-  - id: pydocstyle
-    name: pydocstyle
-    entry: pydocstyle
-    language: python
-    types: [python]
-    additional_dependencies:
-    - "toml"
-  rev: 6.1.1
-- repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.28.0
-  hooks:
-  - id: yamllint
-    name: yamllint
-    description: This hook runs yamllint.
-    entry: yamllint
-    language: python
-    types: [file, yaml]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:
   - id: check-added-large-files
   - id: check-ast
   - id: check-builtin-literals
+    args:
+    - --no-allow-dict-kwargs
   - id: check-case-conflict
   - id: check-docstring-first
   - id: check-executables-have-shebangs
@@ -66,6 +54,7 @@ repos:
   - id: check-yaml
   - id: debug-statements
   - id: destroyed-symlinks
+  - id: double-quote-string-fixer
   - id: end-of-file-fixer
   - id: fix-byte-order-marker
   - id: mixed-line-ending
@@ -81,6 +70,31 @@ repos:
     - "#"
     - --allow-past-years
     types: [python]
+- repo: https://github.com/PyCQA/docformatter
+  rev: v1.7.7
+  hooks:
+  - id: docformatter
+    args: [--in-place, --wrap-summaries=80, --wrap-descriptions=80]
+- repo: https://github.com/PyCQA/pydocstyle
+  hooks:
+  - id: pydocstyle
+    name: pydocstyle
+    entry: pydocstyle
+    language: python
+    types: [python]
+    exclude: (.ci|.github)
+    additional_dependencies:
+    - toml
+  rev: 6.1.1
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.28.0
+  hooks:
+  - id: yamllint
+    name: yamllint
+    description: This hook runs yamllint.
+    entry: yamllint
+    language: python
+    types: [file, yaml]
 - repo: local
   hooks:
   - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,11 +70,6 @@ repos:
     - "#"
     - --allow-past-years
     types: [python]
-- repo: https://github.com/PyCQA/docformatter
-  rev: v1.7.7
-  hooks:
-  - id: docformatter
-    args: [--in-place, --wrap-summaries=80, --wrap-descriptions=80]
 - repo: https://github.com/PyCQA/pydocstyle
   hooks:
   - id: pydocstyle

--- a/compose_rl/algorithms/online/model_methods.py
+++ b/compose_rl/algorithms/online/model_methods.py
@@ -247,7 +247,11 @@ def policy_loss(
             logits=gen_logits,
         )
         assert token_entropies.shape == batch['action_mask'].shape, (
-            f'Token entropies shape {token_entropies.shape} does not match action mask shape {batch["action_mask"].shape}.',
+            'Token entropies shape {token_entropies_shape} does not match action mask shape {action_mask_shape}.'
+            .format(
+                token_entropies_shape=token_entropies.shape,
+                action_mask_shape=batch['action_mask'].shape,
+            ),
         )
         seq_entropies = utils.get_sequence_entropies(
             token_entropies=token_entropies,

--- a/compose_rl/algorithms/reward_modeling/model.py
+++ b/compose_rl/algorithms/reward_modeling/model.py
@@ -1,5 +1,6 @@
 # Copyright 2024 MosaicML ComposeRL authors
 # SPDX-License-Identifier: Apache-2.0
+
 """Reward Model Composer Implementation."""
 
 import logging

--- a/compose_rl/algorithms/reward_modeling/model.py
+++ b/compose_rl/algorithms/reward_modeling/model.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML ComposeRL authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Reward Model Composer Implementation."""
 
 import logging
@@ -329,7 +328,7 @@ class ComposerHFCausalClassifierRewardModel(ComposerHFCausalLM, RewardModel):
                 batch['input_ids'],
                 attention_mask=batch['attention_mask'],
             ).logits
-            logits = logits[:, :, self.eos_token_id]
+            logits = logits[:, :, self.eos_token_id]  # type: ignore
             if self.min_threshold is not None and self.max_threshold is not None:
                 logits: torch.Tensor = torch.clamp(
                     logits,


### PR DESCRIPTION
Removed `docformatter` because there are cases where the changes that it makes breaks the changes that `yapf` makes and therefore, can lead to errors when we are making PRs.

Also made some minor tweaks to address other common failures that we're seeing during pyright and double quotes.